### PR TITLE
React Async v4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
   },
   "settings": {
     "react": {
-      "version": "16.3"
+      "version": "16.8"
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
 cache:
   directories:
     - node_modules
-script: npm run test:compat && npm run test:hook
+script: npm run test:compat
 after_success:
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ error states, without assumptions about the shape of your data or the type of re
 
 - Zero dependencies
 - Works with any (native) Promise and the Fetch API
-- Choose between Render Props, Context-based helper components or the `useAsync` hook
+- Choose between Render Props, Context-based helper components or the `useAsync` and `useFetch` hooks
 - Provides convenient `isLoading`, `startedAt` and `finishedAt` metadata
 - Provides `cancel` and `reload` actions
 - Automatic re-run using `watch` or `watchFn` prop

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ error states, without assumptions about the shape of your data or the type of re
 - [Installation](#installation)
 - [Usage](#usage)
   - [As a hook](#as-a-hook)
+    - [With `useFetch`](#with-usefetch)
   - [As a component](#as-a-component)
     - [With helper components](#with-helper-components)
-  - [As a constructor](#as-a-constructor)
+  - [As a factory](#as-a-factory)
 - [API](#api)
 - [Helper components](#helper-components)
 - [Usage examples](#usage-examples)
@@ -122,7 +123,7 @@ yarn add react-async
 ## Usage
 
 React Async offers three primary APIs: the `useAsync` hook, the `<Async>` component and the `createInstance`
-constructor. Each has its unique benefits and downsides.
+factory function. Each has its unique benefits and downsides.
 
 ### As a hook
 
@@ -160,6 +161,24 @@ const MyComponent = () => {
   // ...
 }
 ```
+
+#### With `useFetch`
+
+Because fetch is so commonly used with `useAsync`, there's a dedicated `useFetch` hook for it:
+
+```js
+const MyComponent = () => {
+  const headers = { Accept: "application/json" }
+  const { data, error, isLoading, run } = useFetch("/api/example", { headers }, options)
+  // This will setup a promiseFn with a fetch request and JSON deserialization.
+}
+```
+
+`useFetch` takes the same arguments as [fetch] itself, as well as options to the underlying `useAsync` hook. `useFetch`
+automatically uses `promiseFn` or `deferFn` based on the request method (`deferFn` for POST / PUT / PATCH / DELETE) and
+handles JSON parsing if the `Accept` header is set to `"application/json"`.
+
+[fetch]: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
 
 ### As a component
 
@@ -223,7 +242,7 @@ const MyComponent = () => (
 )
 ```
 
-### As a constructor
+### As a factory
 
 You can also create your own component instances, allowing you to preconfigure them with options such as default
 `onResolve` and `onReject` callbacks.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ const MyComponent = () => {
 Because fetch is so commonly used with `useAsync`, there's a dedicated `useFetch` hook for it:
 
 ```js
+import { useFetch } from "react-async"
+
 const MyComponent = () => {
   const headers = { Accept: "application/json" }
   const { data, error, isLoading, run } = useFetch("/api/example", { headers }, options)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,35 @@ error states, without assumptions about the shape of your data or the type of re
 
 [abortable fetch]: https://developers.google.com/web/updates/2017/09/abortable-fetch
 
+> ## Upgrading to v4
+>
+> When upgrading to React Async v4, please note the following breaking API changes:
+>
+> - `deferFn` now receives an `args` array as the third argument, instead of arguments to `run` being spread at the front
+>   of the arguments list. This enables better interop with TypeScript. You can use destructuring to keep using your
+>   existing variables.
+> - The shorthand version of `useAsync` now takes the `options` object as optional second argument. This used to be
+>   `initialValue`, but was undocumented and inflexible.
+
+# Table of Contents
+
+- [Rationale](#rationale)
+  - [Concurrent React and Suspense](#concurrent-react-and-suspense)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [As a hook](#as-a-hook)
+  - [As a component](#as-a-component)
+    - [With helper components](#with-helper-components)
+  - [As a constructor](#as-a-constructor)
+- [API](#api)
+- [Helper components](#helper-components)
+- [Usage examples](#usage-examples)
+  - [Data fetching](#data-fetching)
+  - [Form submission](#form-submission)
+  - [Optimistic updates](#optimistic-updates)
+  - [Server-side rendering](#server-side-rendering)
+- [Acknowledgements](#acknowledgements)
+
 ## Rationale
 
 React Async is different in that it tries to resolve data as close as possible to where it will be used, while using a
@@ -62,7 +91,7 @@ from your routes, so it works well in complex applications that have a dynamic r
 
 React Async is promise-based, so you can resolve anything you want, not just `fetch` requests.
 
-## Concurrent React and Suspense
+### Concurrent React and Suspense
 
 The React team is currently working on a large rewrite called [Concurrent React], previously known as "Async React".
 Part of this rewrite is Suspense, which is a generic way for components to suspend rendering while they load data from
@@ -75,15 +104,30 @@ you can already **start using React Async right now**, and in a later update you
 
 [concurrent react]: https://github.com/sw-yx/fresh-concurrent-react/blob/master/Intro.md#introduction-what-is-concurrent-react
 
-## Install
+## Installation
 
 ```
 npm install --save react-async
 ```
 
+Or with Yarn:
+
+```
+yarn add react-async
+```
+
+> This package requires `react` as a peer dependency. Please make sure to install that as well.
+> If you want to use the `useAsync` hook, you'll need `react@16.8.0` or later.
+
 ## Usage
 
-As a hook with `useAsync` (available [from React v16.8.0](https://reactjs.org/hooks)):
+React Async offers three primary APIs: the `useAsync` hook, the `<Async>` component and the `createInstance`
+constructor. Each has its unique benefits and downsides.
+
+### As a hook
+
+The `useAsync` hook (available [from React v16.8.0](https://reactjs.org/hooks)) offers direct access to React Async's
+core functionality from within your own function components:
 
 ```js
 import { useAsync } from "react-async"
@@ -117,7 +161,10 @@ const MyComponent = () => {
 }
 ```
 
-Using render props for flexibility:
+### As a component
+
+The classic interface to React Async. Simply use <Async> directly in your JSX component tree, leveraging the render
+props pattern:
 
 ```js
 import Async from "react-async"
@@ -146,7 +193,11 @@ const MyComponent = () => (
 )
 ```
 
-Using helper components (don't have to be direct children) for ease of use:
+#### With helper components
+
+Several [helper components](#helper-components) are available for better legibility. These don't have to be direct
+children of `<Async>`, because they use Context, offering full flexibility. You can even use render props and helper
+components together.
 
 ```js
 import Async from "react-async"
@@ -172,7 +223,10 @@ const MyComponent = () => (
 )
 ```
 
-Creating a custom instance of Async, bound to a specific promiseFn:
+### As a constructor
+
+You can also create your own component instances, allowing you to preconfigure them with options such as default
+`onResolve` and `onReject` callbacks.
 
 ```js
 import { createInstance } from "react-async"
@@ -192,21 +246,26 @@ const MyComponent = () => (
 )
 ```
 
-> Similarly, this allows you to set default `onResolve` and `onReject` callbacks.
-
 ## API
 
-### Props
+### Options
 
-`<Async>` takes the following properties:
+These can be passes in an object to `useAsync`, or as props to `<Async>` and custom instances.
 
-- `promiseFn` {(props, controller) => Promise} A function that returns a promise; invoked in `componentDidMount` and `componentDidUpdate`; receives component props (object) and AbortController instance as arguments
-- `deferFn` {(...args, props, controller) => Promise} A function that returns a promise; invoked only by calling `run(...args)`, with arguments being passed through, as well as component props (object) and AbortController as final arguments
-- `watch` {any} Watches this property through `componentDidUpdate` and re-runs the `promiseFn` when the value changes (`oldValue !== newValue`)
-- `watchFn` {(props, prevProps) => any} Re-runs the `promiseFn` when this callback returns truthy (called on every update).
-- `initialValue` {any} initial state for `data` or `error` (if instance of Error); useful for server-side rendering
-- `onResolve` {Function} Callback function invoked when a promise resolves, receives data as argument
-- `onReject` {Function} Callback function invoked when a promise rejects, receives error as argument
+- `promiseFn` Function that returns a Promise, automatically invoked.
+- `deferFn` Function that returns a Promise, manually invoked with `run`.
+- `watch` Watch a value and automatically reload when it changes.
+- `watchFn` Watch this function and automatically reload when it returns truthy.
+- `initialValue` Provide initial data or error for server-side rendering.
+- `onResolve` Callback invoked when Promise resolves.
+- `onReject` Callback invoked when Promise rejects.
+
+#### `promiseFn`
+
+> `function(props: object, controller: AbortController): Promise`
+
+A function that returns a promise. It is automatically invoked in `componentDidMount` and `componentDidUpdate`.
+The function receives all component props (or options) and an AbortController instance as arguments.
 
 > Be aware that updating `promiseFn` will trigger it to cancel any pending promise and load the new promise. Passing an
 > arrow function will cause it to change and reload on every render of the parent component. You can avoid this by
@@ -214,35 +273,237 @@ const MyComponent = () => (
 > pass them as additional props to `<Async>`, as `promiseFn` will be invoked with these props. Alternatively you can
 > use [memoization](https://github.com/alexreardon/memoize-one) to avoid unnecessary updates.
 
+#### `deferFn`
+
+> `function(props: object, controller: AbortController, args: any[]): Promise`
+
+A function that returns a promise. This is invoked only by manually calling `run(...args)`. Receives the same arguments
+as `promiseFn`, as well as any arguments to `run` which are passed through as an array. The `deferFn` is commonly used
+to send data to the server following a user action, such as submitting a form. You can use this in conjunction with
+`promiseFn` to fill the form with existing data, then updating it on submit with `deferFn`.
+
+> Be aware that when using both `promiseFn` and `deferFn`, the shape of their resolved value should match, because they
+> both update the `data`.
+
+#### `watch`
+
+> `boolean | any`
+
+Watches this property through `componentDidUpdate` and re-runs the `promiseFn` when the value changes, using a simple
+reference check (`oldValue !== newValue`). If you need a more complex update check, use `watchFn` instead.
+
+#### `watchFn`
+
+> `function(props: object, prevProps: object): boolean | any`
+
+Re-runs the `promiseFn` when this callback returns truthy (called on every update). Any default props specified by
+`createInstance` are available too.
+
+#### `initialValue`
+
+> `any | Error`
+
+Initial state for `data` or `error` (if instance of Error); useful for server-side rendering.
+
+#### `onResolve`
+
+> `function(data: any): any`
+
+Callback function invoked when a promise resolves, receives data as argument.
+
+#### `onReject`
+
+> `function(reason: Error): any`
+
+Callback function invoked when a promise rejects, receives rejection reason (error) as argument.
+
 ### Render props
 
-`<Async>` provides the following render props:
+`<Async>` provides the following render props to the `children` function:
 
-- `data` {any} last resolved promise value, maintained when new error arrives
-- `error` {Error} rejected promise reason, cleared when new data arrives
-- `initialValue` {any} the data or error that was provided through the `initialValue` prop
-- `isLoading` {boolean} `true` while a promise is pending
-- `startedAt` {Date} when the current/last promise was started
-- `finishedAt` {Date} when the last promise was resolved or rejected
-- `cancel` {Function} ignores the result of the currently pending promise and calls `abort()` on the AbortController
-- `run` {Function} runs the `deferFn`, passing any arguments provided
-- `reload` {Function} re-runs the promise when invoked, using the previous arguments
-- `setData` {Function} sets `data` to the passed value, unsets `error` and cancels any pending promise
-- `setError` {Function} sets `error` to the passed value and cancels any pending promise
+- `data` Last resolved promise value, maintained when new error arrives.
+- `error` Rejected promise reason, cleared when new data arrives.
+- `initialValue` The data or error that was provided through the `initialValue` prop.
+- `isLoading` Whether or not a Promise is currently pending.
+- `startedAt` When the current/last promise was started.
+- `finishedAt` When the last promise was resolved or rejected.
+- `cancel` Cancel any pending promise.
+- `run` Invokes the `deferFn`.
+- `reload` Re-runs the promise when invoked, using the any previous arguments.
+- `setData` Sets `data` to the passed value, unsets `error` and cancels any pending promise.
+- `setError` Sets `error` to the passed value and cancels any pending promise.
 
-### `useAsync` (API may change until Hooks are officially released)
+#### `data`
 
-The `useAsync` hook accepts an object with the same props as `<Async>`. Alternatively you can use the shorthand syntax:
+> `any`
+
+Last resolved promise value, maintained when new error arrives.
+
+#### `error`
+
+> `Error`
+
+Rejected promise reason, cleared when new data arrives.
+
+#### `initialValue`
+
+> `any | Error`
+
+The data or error that was originally provided through the `initialValue` prop.
+
+#### `isLoading`
+
+> `boolean`
+
+`true` while a promise is pending, `false` otherwise.
+
+#### `startedAt`
+
+> `Date`
+
+Tracks when the current/last promise was started.
+
+#### `finishedAt`
+
+> `Date`
+
+Tracks when the last promise was resolved or rejected.
+
+#### `cancel`
+
+> `function(): void`
+
+Cancels the currently pending promise by ignoring its result and calls `abort()` on the AbortController.
+
+#### `run`
+
+> `function(...args: any[]): Promise`
+
+Runs the `deferFn`, passing any arguments provided as an array.
+
+#### `reload`
+
+> `function(): void`
+
+Re-runs the promise when invoked, using the previous arguments.
+
+#### `setData`
+
+> `function(data: any): any`
+
+Sets `data` to the passed value, unsets `error` and cancels any pending promise. Returns the data to enable chaining.
+
+#### `setError`
+
+> `function(error: Error): Error`
+
+Sets `error` to the passed value and cancels any pending promise. Returns the error to enable chaining.
+
+## Helper components
+
+React Async provides several helper components that make your JSX more declarative and less cluttered.
+They don't have to be direct children of `<Async>` and you can use the same component several times.
+
+### `<Async.Loading>`
+
+This component renders only while the promise is loading.
+
+#### Props
+
+- `initial` `boolean` Show only on initial load (when `data` is `undefined`).
+- `children` `function(state: object): Node | Node` Render function or React Node.
+
+#### Examples
 
 ```js
-useAsync(promiseFn, initialValue)
+<Async.Loading initial>
+  <p>This text is only rendered while performing the initial load.</p>
+</Async.Loading>
 ```
 
-Note that the `useAsync` API is subject to change while Hooks are not officially released.
+```js
+<Async.Loading>{({ startedAt }) => `Loading since ${startedAt.toISOString()}`}</Async.Loading>
+```
 
-## Examples
+### `<Async.Resolved>`
 
-### Basic data fetching with loading indicator, error state and retry
+This component renders only when the promise is resolved with data (`data !== undefined`).
+
+#### Props
+
+- `persist` `boolean` Show old data while loading new data. By default it hides as soon as a new promise starts.
+- `children` `function(data: any, state: object): Node | Node` Render function or React Node.
+
+#### Examples
+
+```js
+<Async.Resolved persist>{data => <pre>{JSON.stringify(data)}</pre>}</Async.Resolved>
+```
+
+```js
+<Async.Resolved>{({ finishedAt }) => `Last updated ${startedAt.toISOString()}`}</Async.Resolved>
+```
+
+### `<Async.Rejected>`
+
+This component renders only when the promise is rejected.
+
+#### Props
+
+- `persist` `boolean` Show old error while loading new data. By default it hides as soon as a new promise starts.
+- `children` `function(error: Error, state: object): Node | Node` Render function or React Node.
+
+#### Examples
+
+```js
+<Async.Rejected persist>Oops.</Async.Rejected>
+```
+
+```js
+<Async.Rejected>{error => `Unexpected error: ${error.message}`}</Async.Rejected>
+```
+
+### `<Async.Pending>`
+
+Renders only while the deferred promise is still pending (not yet run).
+
+#### Props
+
+- `persist` `boolean` Show until we have data, even while loading or when an error occurred. By default it hides as soon as the promise starts loading.
+- `children` `function(state: object): Node | Node` Render function or React Node.
+
+#### Examples
+
+```js
+<Async deferFn={deferFn}>
+  <Async.Pending>
+    <p>This text is only rendered while `run` has not yet been invoked on `deferFn`.</p>
+  </Async.Pending>
+</Async>
+```
+
+```js
+<Async.Pending persist>
+  {({ error, isLoading, run }) => (
+    <div>
+      <p>This text is only rendered while the promise has not resolved yet.</p>
+      <button onClick={run} disabled={!isLoading}>
+        Run
+      </button>
+      {error && <p>{error.message}</p>}
+    </div>
+  )}
+</Async.Pending>
+```
+
+## Usage examples
+
+Here's several examples to give you an idea of what's possible with React Async. For fully working examples, please
+check out the [`examples` directory](https://github.com/ghengeveld/react-async/tree/master/examples).
+
+### Data fetching
+
+This does some basic data fetching, including a loading indicator, error state and retry.
 
 ```js
 class App extends Component {
@@ -275,10 +536,12 @@ class App extends Component {
 }
 ```
 
-### Using `deferFn` to trigger an update (e.g. POST / PUT request)
+### Form submission
+
+This uses `deferFn` to trigger an update (e.g. POST / PUT request) after a form submit.
 
 ```js
-const subscribeToNewsletter = (event, props, controller) => fetch(...)
+const subscribeToNewsletter = (props, controller, args) => fetch(...)
 
 <Async deferFn={subscribeToNewsletter}>
   {({ error, isLoading, run }) => (
@@ -293,10 +556,12 @@ const subscribeToNewsletter = (event, props, controller) => fetch(...)
 </Async>
 ```
 
-### Using both `promiseFn` and `deferFn` along with `setData` to implement optimistic updates
+### Optimistic updates
+
+This uses both `promiseFn` and `deferFn` along with `setData` to implement optimistic updates.
 
 ```js
-const updateAttendance = attend => fetch(...).then(() => attend, () => !attend)
+const updateAttendance = (props, ctrl, [attend]) => fetch(...).then(() => attend, () => !attend)
 
 <Async promiseFn={getAttendance} deferFn={updateAttendance}>
   {({ data: isAttending, isLoading, run, setData }) => (
@@ -312,7 +577,9 @@ const updateAttendance = attend => fetch(...).then(() => attend, () => !attend)
 </Async>
 ```
 
-### Server-side rendering using `initialValue` (e.g. Next.js)
+### Server-side rendering
+
+This uses `initialValue` to enable server-side rendering with Next.js.
 
 ```js
 static async getInitialProps() {
@@ -342,105 +609,8 @@ render() {
 }
 ```
 
-## Helper components
-
-React Async provides several helper components that make your JSX even more declarative.
-They don't have to be direct children of `<Async>` and you can use the same component several times.
-
-### `<Async.Loading>`
-
-Renders only while the promise is loading.
-
-#### Props
-
-- `initial` {boolean} Show only on initial load (data is undefined)
-- `children` {Function|Node} Function which receives props object or React node
-
-#### Examples
-
-```js
-<Async.Loading initial>
-  <p>This text is only rendered while performing the initial load.</p>
-</Async.Loading>
-```
-
-```js
-<Async.Loading>{({ startedAt }) => `Loading since ${startedAt.toISOString()}`}</Async.Loading>
-```
-
-### `<Async.Resolved>`
-
-Renders only when the promise is resolved with data (`data !== undefined`).
-
-#### Props
-
-- `persist` {boolean} Show old data while loading new data. By default it hides as soon as a new promise starts.
-- `children` {Function|Node} Render function which receives data and props object or just a plain React node.
-
-#### Examples
-
-```js
-<Async.Resolved persist>{data => <pre>{JSON.stringify(data)}</pre>}</Async.Resolved>
-```
-
-```js
-<Async.Resolved>{({ finishedAt }) => `Last updated ${startedAt.toISOString()}`}</Async.Resolved>
-```
-
-### `<Async.Rejected>`
-
-Renders only when the promise is rejected.
-
-#### Props
-
-- `persist` {boolean} Show old error while loading new data. By default it hides as soon as a new promise starts.
-- `children` {Function|Node} Render function which receives error and props object or just a plain React node.
-
-#### Examples
-
-```js
-<Async.Rejected persist>Oops.</Async.Rejected>
-```
-
-```js
-<Async.Rejected>{error => `Unexpected error: ${error.message}`}</Async.Rejected>
-```
-
-### `<Async.Pending>`
-
-Renders only while the deferred promise is still pending (not yet run).
-
-#### Props
-
-- `persist` {boolean} Show until we have data, even while loading or when an error occurred. By default it hides as soon as the promise starts loading.
-- `children` {Function|Node} Function which receives props object or React node.
-
-#### Examples
-
-```js
-<Async deferFn={deferFn}>
-  <Async.Pending>
-    <p>This text is only rendered while `run` has not yet been invoked on `deferFn`.</p>
-  </Async.Pending>
-</Async>
-```
-
-```js
-<Async.Pending persist>
-  {({ error, isLoading, run }) => (
-    <div>
-      <p>This text is only rendered while the promise has not resolved yet.</p>
-      <button onClick={run} disabled={!isLoading}>
-        Run
-      </button>
-      {error && <p>{error.message}</p>}
-    </div>
-  )}
-</Async.Pending>
-```
-
 ## Acknowledgements
 
 Versions 1.x and 2.x of `react-async` on npm are from a different project abandoned years ago. The original author was
-kind enough to transfer ownership so the `react-async` package name could be repurposed. The first version of
-React Async is v3.0.0. Many thanks to Andrey Popp for handing over ownership of `react-async` on npm.
+kind enough to transfer ownership so the `react-async` package name could be repurposed. The first version of this
+project is v3.0.0. Many thanks to Andrey Popp for handing over ownership of `react-async` on npm.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ error states, without assumptions about the shape of your data or the type of re
 >
 > When upgrading to React Async v4, please note the following breaking API changes:
 >
-> - `deferFn` now receives an `args` array as the third argument, instead of arguments to `run` being spread at the front
+> - `deferFn` now receives an `args` array as the first argument, instead of arguments to `run` being spread at the front
 >   of the arguments list. This enables better interop with TypeScript. You can use destructuring to keep using your
 >   existing variables.
 > - The shorthand version of `useAsync` now takes the `options` object as optional second argument. This used to be
@@ -275,7 +275,7 @@ The function receives all component props (or options) and an AbortController in
 
 #### `deferFn`
 
-> `function(props: object, controller: AbortController, args: any[]): Promise`
+> `function(args: any[], props: object, controller: AbortController): Promise`
 
 A function that returns a promise. This is invoked only by manually calling `run(...args)`. Receives the same arguments
 as `promiseFn`, as well as any arguments to `run` which are passed through as an array. The `deferFn` is commonly used
@@ -543,7 +543,7 @@ class App extends Component {
 This uses `deferFn` to trigger an update (e.g. POST / PUT request) after a form submit.
 
 ```js
-const subscribeToNewsletter = (props, controller, args) => fetch(...)
+const subscribeToNewsletter = (args, props, controller) => fetch(...)
 
 <Async deferFn={subscribeToNewsletter}>
   {({ error, isLoading, run }) => (
@@ -563,7 +563,7 @@ const subscribeToNewsletter = (props, controller, args) => fetch(...)
 This uses both `promiseFn` and `deferFn` along with `setData` to implement optimistic updates.
 
 ```js
-const updateAttendance = (props, ctrl, [attend]) => fetch(...).then(() => attend, () => !attend)
+const updateAttendance = ([attend]) => fetch(...).then(() => attend, () => !attend)
 
 <Async promiseFn={getAttendance} deferFn={updateAttendance}>
   {({ data: isAttending, isLoading, run, setData }) => (

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
   </a>
 </p>
 
-React component for declarative promise resolution and data fetching. Leverages the Render Props pattern and Hooks for
-ultimate flexibility as well as the new Context API for ease of use. Makes it easy to handle loading and error states,
-without assumptions about the shape of your data or the type of request.
+React component and hook for declarative promise resolution and data fetching. Leverages the Render Props pattern and
+Hooks for ultimate flexibility as well as the new Context API for ease of use. Makes it easy to handle loading and
+error states, without assumptions about the shape of your data or the type of request.
 
 - Zero dependencies
 - Works with any (native) Promise and the Fetch API
@@ -82,6 +82,40 @@ npm install --save react-async
 ```
 
 ## Usage
+
+As a hook with `useAsync` (available [from React v16.8.0](https://reactjs.org/hooks)):
+
+```js
+import { useAsync } from "react-async"
+
+const loadCustomer = ({ customerId }, { signal }) =>
+  fetch(`/api/customers/${customerId}`, { signal })
+    .then(res => (res.ok ? res : Promise.reject(res)))
+    .then(res => res.json())
+
+const MyComponent = () => {
+  const { data, error, isLoading } = useAsync({ promiseFn: loadCustomer, customerId: 1 })
+  if (isLoading) return "Loading..."
+  if (error) return `Something went wrong: ${error.message}`
+  if (data)
+    return (
+      <div>
+        <strong>Loaded some data:</strong>
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+      </div>
+    )
+  return null
+}
+```
+
+Or using the shorthand version:
+
+```js
+const MyComponent = () => {
+  const { data, error, isLoading } = useAsync(loadCustomer, options)
+  // ...
+}
+```
 
 Using render props for flexibility:
 
@@ -159,42 +193,6 @@ const MyComponent = () => (
 ```
 
 > Similarly, this allows you to set default `onResolve` and `onReject` callbacks.
-
-As a hook with `useAsync` (currently [only in React v16.7.0-alpha](https://reactjs.org/hooks); API is subject to change):
-
-```js
-import { useAsync } from "react-async"
-
-const loadCustomer = ({ customerId }, { signal }) =>
-  fetch(`/api/customers/${customerId}`, { signal })
-    .then(res => (res.ok ? res : Promise.reject(res)))
-    .then(res => res.json())
-
-const MyComponent = () => {
-  const { data, error, isLoading } = useAsync({ promiseFn: loadCustomer, customerId: 1 })
-  if (isLoading) return "Loading..."
-  if (error) return `Something went wrong: ${error.message}`
-  if (data)
-    return (
-      <div>
-        <strong>Loaded some data:</strong>
-        <pre>{JSON.stringify(data, null, 2)}</pre>
-      </div>
-    )
-  return null
-}
-```
-
-Or using the shorthand version:
-
-```js
-const MyComponent = () => {
-  const { data, error, isLoading } = useAsync(loadCustomer)
-  // ...
-}
-```
-
-The shorthand version currently does not support passing additional props.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ error states, without assumptions about the shape of your data or the type of re
     - [With helper components](#with-helper-components)
   - [As a factory](#as-a-factory)
 - [API](#api)
+  - [Options](#options)
+  - [Render props](#render-props)
 - [Helper components](#helper-components)
 - [Usage examples](#usage-examples)
   - [Data fetching](#data-fetching)

--- a/README.md
+++ b/README.md
@@ -307,13 +307,13 @@ Initial state for `data` or `error` (if instance of Error); useful for server-si
 
 #### `onResolve`
 
-> `function(data: any): any`
+> `function(data: any): void`
 
 Callback function invoked when a promise resolves, receives data as argument.
 
 #### `onReject`
 
-> `function(reason: Error): any`
+> `function(reason: Error): void`
 
 Callback function invoked when a promise rejects, receives rejection reason (error) as argument.
 
@@ -389,15 +389,17 @@ Re-runs the promise when invoked, using the previous arguments.
 
 #### `setData`
 
-> `function(data: any): any`
+> `function(data: any, callback?: () => void): any`
 
-Sets `data` to the passed value, unsets `error` and cancels any pending promise. Returns the data to enable chaining.
+Function that sets `data` to the passed value, unsets `error` and cancels any pending promise. Takes an optional
+callback which is invoked after the state update is completed. Returns the data to enable chaining.
 
 #### `setError`
 
-> `function(error: Error): Error`
+> `function(error: Error, callback?: () => void): Error`
 
-Sets `error` to the passed value and cancels any pending promise. Returns the error to enable chaining.
+Function that sets `error` to the passed value and cancels any pending promise. Takes an optional callback which is
+invoked after the state update is completed. Returns the error to enable chaining.
 
 ## Helper components
 

--- a/examples/with-abortcontroller/src/index.js
+++ b/examples/with-abortcontroller/src/index.js
@@ -3,7 +3,7 @@ import { useAsync } from "react-async"
 import ReactDOM from "react-dom"
 import "./index.css"
 
-const download = (event, props, controller) =>
+const download = (args, props, controller) =>
   fetch(`https://reqres.in/api/users/1?delay=3`, { signal: controller.signal })
     .then(res => (res.ok ? res : Promise.reject(res)))
     .then(res => res.json())

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test:watch": "npm run test -- --watch",
     "test:compat": "npm run test:backwards && npm run test:forwards && npm run test:latest",
     "test:backwards": "npm i react@16.3.1 react-dom@16.3.1 && npm test",
-    "test:forwards": "npm i react@next react-dom@next && npm test && test:hook",
-    "test:latest": "npm i react@latest react-dom@latest && npm test && test:hook",
+    "test:forwards": "npm i react@next react-dom@next && npm test && npm run test:hook",
+    "test:latest": "npm i react@latest react-dom@latest && npm test && npm run test:hook",
     "prepublishOnly": "npm run lint && npm run test:compat && npm run build"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "build": "rimraf lib && babel src -d lib --ignore '**/*spec.js'",
     "lint": "eslint src",
     "test": "jest src/spec.js  --collectCoverageFrom=src/index.js",
+    "test:hook": "jest src/useAsync.spec.js --collectCoverageFrom=src/useAsync.js",
     "test:watch": "npm run test -- --watch",
     "test:compat": "npm run test:backwards && npm run test:forwards && npm run test:latest",
     "test:backwards": "npm i react@16.3.1 react-dom@16.3.1 && npm test",
-    "test:forwards": "npm i react@next react-dom@next && npm test",
-    "test:latest": "npm i react@latest react-dom@latest && npm test",
-    "test:hook": "npm i react@16.7.0-alpha.2 react-dom@16.7.0-alpha.2 && jest src/useAsync.spec.js --collectCoverageFrom=src/useAsync.js",
-    "prepublishOnly": "npm run lint && npm run test:compat && npm run test:hook && npm run build"
+    "test:forwards": "npm i react@next react-dom@next && npm test && test:hook",
+    "test:latest": "npm i react@latest react-dom@latest && npm test && test:hook",
+    "prepublishOnly": "npm run lint && npm run test:compat && npm run build"
   },
   "dependencies": {},
   "peerDependencies": {
@@ -57,9 +57,9 @@
     "jest": "23.6.0",
     "jest-dom": "2.1.0",
     "prettier": "1.15.3",
-    "react": "16.6.3",
-    "react-dom": "16.6.3",
-    "react-testing-library": "5.4.2",
+    "react": "16.8.1",
+    "react-dom": "16.8.1",
+    "react-testing-library": "5.5.3",
     "rimraf": "2.6.2"
   },
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       if (!deferFn) return
       this.args = args
       this.start()
-      return deferFn(...args, { ...defaultProps, ...this.props }, this.abortController).then(
+      return deferFn(args, { ...defaultProps, ...this.props }, this.abortController).then(
         this.onResolve(this.counter),
         this.onReject(this.counter)
       )

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-export { default as useAsync } from "./useAsync"
+export { default as useAsync, useFetch } from "./useAsync"
 
 const isFunction = arg => typeof arg === "function"
 

--- a/src/spec.js
+++ b/src/spec.js
@@ -169,9 +169,9 @@ describe("Async", () => {
     const props = { deferFn, foo: "bar" }
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(props), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 1], expect.objectContaining(props), abortCtrl)
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining(props), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining(props), abortCtrl)
   })
 
   test("reload uses the arguments of the previous run", () => {
@@ -191,11 +191,11 @@ describe("Async", () => {
     )
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 1], expect.objectContaining({ deferFn }), abortCtrl)
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining({ deferFn }), abortCtrl)
     fireEvent.click(getByText("reload"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining({ deferFn }), abortCtrl)
   })
 
   test("only accepts the last invocation of the promise", async () => {
@@ -513,9 +513,17 @@ describe("createInstance", () => {
     const expectedProps = { deferFn, foo: "bar" }
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(expectedProps), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(
+      ["go", 1],
+      expect.objectContaining(expectedProps),
+      abortCtrl
+    )
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining(expectedProps), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(
+      ["go", 2],
+      expect.objectContaining(expectedProps),
+      abortCtrl
+    )
   })
 
   test("custom instance correctly passes props to deferFn on reload", async () => {
@@ -537,8 +545,16 @@ describe("createInstance", () => {
     const expectedProps = { deferFn, foo: "bar" }
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(expectedProps), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(
+      ["go", 1],
+      expect.objectContaining(expectedProps),
+      abortCtrl
+    )
     fireEvent.click(getByText("reload"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(expectedProps), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(
+      ["go", 1],
+      expect.objectContaining(expectedProps),
+      abortCtrl
+    )
   })
 })

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -64,7 +64,7 @@ const useAsync = (arg1, arg2) => {
     if (deferFn) {
       lastArgs.current = args
       start()
-      return deferFn(...args, options, abortController.current).then(
+      return deferFn(args, options, abortController.current).then(
         handleResolve(counter.current),
         handleReject(counter.current)
       )

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -1,16 +1,13 @@
 import { useState, useEffect, useMemo, useRef } from "react"
 
-const useAsync = (opts, init) => {
+const useAsync = (arg1, arg2) => {
   const counter = useRef(0)
   const isMounted = useRef(true)
   const lastArgs = useRef(undefined)
   const prevOptions = useRef(undefined)
   const abortController = useRef({ abort: () => {} })
 
-  if (typeof opts === "function" && init) {
-    console.warn("`useAsync(promiseFn, initialValue)` is deprecated and will be removed soon.")
-  }
-  const options = typeof opts === "function" ? { promiseFn: opts, initialValue: init } : opts
+  const options = typeof arg1 === "function" ? { ...arg2, promiseFn: arg1 } : arg1
   const { promiseFn, deferFn, initialValue, onResolve, onReject, watch, watchFn } = options
 
   const [state, setState] = useState({
@@ -105,7 +102,7 @@ const useAsync = (opts, init) => {
 
 const unsupported = () => {
   throw new Error(
-    "useAsync requires react@16.7.0-alpha. Upgrade your React version or use the <Async> component instead."
+    "useAsync requires React v16.8 or up. Upgrade your React version or use the <Async> component instead."
   )
 }
 

--- a/src/useAsync.spec.js
+++ b/src/useAsync.spec.js
@@ -1,6 +1,6 @@
 import "jest-dom/extend-expect"
 import React from "react"
-import { render, fireEvent, cleanup, waitForElement, flushEffects } from "react-testing-library"
+import { render, fireEvent, cleanup, waitForElement } from "react-testing-library"
 import { useAsync } from "."
 
 const abortCtrl = { abort: jest.fn() }
@@ -16,10 +16,9 @@ const Async = ({ children = () => null, ...props }) => children(useAsync(props))
 
 describe("useAsync", () => {
   test("returns render props", async () => {
-    const promiseFn = () => new Promise(resolve => setTimeout(resolve, 0, "done"))
+    const promiseFn = () => Promise.resolve("done")
     const component = <Async promiseFn={promiseFn}>{({ data }) => data || null}</Async>
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("done"))
   })
 
@@ -27,7 +26,6 @@ describe("useAsync", () => {
     const promiseFn = () => Promise.reject("oops")
     const component = <Async promiseFn={promiseFn}>{({ error }) => error || null}</Async>
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("oops"))
   })
 
@@ -43,7 +41,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("done"))
     expect(states).toEqual([true, true, false])
   })
@@ -62,7 +59,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("started"))
   })
 
@@ -80,7 +76,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("done"))
   })
 
@@ -92,7 +87,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(1)
     fireEvent.click(getByText("reload"))
     expect(promiseFn).toHaveBeenCalledTimes(2)
@@ -115,14 +109,11 @@ describe("useAsync", () => {
     const promiseFn = jest.fn().mockReturnValue(resolveTo())
     const component = <Counter>{count => <Async promiseFn={promiseFn} watch={count} />}</Counter>
     const { getByText } = render(component)
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(1)
     fireEvent.click(getByText("increment"))
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(2)
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
     fireEvent.click(getByText("increment"))
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(3)
     expect(abortCtrl.abort).toHaveBeenCalledTimes(2)
   })
@@ -146,14 +137,11 @@ describe("useAsync", () => {
       <Counter>{count => <Async promiseFn={promiseFn} watchFn={watchFn} count={count} />}</Counter>
     )
     const { getByText } = render(component)
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(1)
     fireEvent.click(getByText("increment"))
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(1)
     expect(abortCtrl.abort).toHaveBeenCalledTimes(0)
     fireEvent.click(getByText("increment"))
-    flushEffects()
     expect(promiseFn).toHaveBeenCalledTimes(2)
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
   })
@@ -170,7 +158,6 @@ describe("useAsync", () => {
     )
     const { getByText } = render(component)
     const props = { deferFn, foo: "bar" }
-    flushEffects()
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
     expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(props), abortCtrl)
@@ -187,7 +174,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     fireEvent.click(getByText("cancel"))
     await Promise.resolve()
     expect(onResolve).not.toHaveBeenCalled()
@@ -210,7 +196,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
     expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining({ deferFn }), abortCtrl)
@@ -248,7 +233,6 @@ describe("useAsync", () => {
     const onResolve = jest.fn()
     const component = <Async promiseFn={promiseFn} onResolve={onResolve} />
     render(component)
-    flushEffects()
     await Promise.resolve()
     expect(onResolve).toHaveBeenCalledWith("ok")
   })
@@ -258,7 +242,6 @@ describe("useAsync", () => {
     const onReject = jest.fn()
     const component = <Async promiseFn={promiseFn} onReject={onReject} />
     render(component)
-    flushEffects()
     await Promise.resolve()
     expect(onReject).toHaveBeenCalledWith("err")
   })
@@ -268,7 +251,6 @@ describe("useAsync", () => {
     const onResolve = jest.fn()
     const component = <Async promiseFn={promiseFn} onResolve={onResolve} />
     const { unmount } = render(component)
-    flushEffects()
     unmount()
     await Promise.resolve()
     expect(onResolve).not.toHaveBeenCalled()
@@ -276,37 +258,31 @@ describe("useAsync", () => {
   })
 
   test("cancels and restarts the promise when promiseFn changes", async () => {
-    const promiseFn1 = jest.fn().mockReturnValue(Promise.resolve("one"))
-    const promiseFn2 = jest.fn().mockReturnValue(Promise.resolve("two"))
+    const promiseFn1 = jest.fn().mockReturnValue(resolveTo("one"))
+    const promiseFn2 = jest.fn().mockReturnValue(resolveTo("two"))
     const onResolve = jest.fn()
     const component1 = <Async promiseFn={promiseFn1} onResolve={onResolve} />
     const component2 = <Async promiseFn={promiseFn2} onResolve={onResolve} />
     const { rerender } = render(component1)
-    await Promise.resolve()
-    flushEffects()
     expect(promiseFn1).toHaveBeenCalled()
     rerender(component2)
-    flushEffects()
     expect(promiseFn2).toHaveBeenCalled()
+    await resolveTo()
     expect(onResolve).not.toHaveBeenCalledWith("one")
-    await Promise.resolve()
     expect(onResolve).toHaveBeenCalledWith("two")
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
   })
 
   test("cancels the promise when promiseFn is unset", async () => {
-    const promiseFn = jest.fn().mockReturnValue(Promise.resolve("one"))
+    const promiseFn = jest.fn().mockReturnValue(resolveTo("one"))
     const onResolve = jest.fn()
     const component1 = <Async promiseFn={promiseFn} onResolve={onResolve} />
     const component2 = <Async onResolve={onResolve} />
     const { rerender } = render(component1)
-    await Promise.resolve()
-    flushEffects()
     expect(promiseFn).toHaveBeenCalled()
     rerender(component2)
-    flushEffects()
+    await resolveTo()
     expect(onResolve).not.toHaveBeenCalledWith("one")
-    await Promise.resolve()
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
   })
 
@@ -314,7 +290,6 @@ describe("useAsync", () => {
     const promiseFn = jest.fn().mockReturnValue(Promise.resolve())
     const component = <Async promiseFn={promiseFn} initialValue={{}} />
     render(component)
-    flushEffects()
     expect(promiseFn).not.toHaveBeenCalled()
   })
 
@@ -330,7 +305,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("done"))
     expect(states).toEqual([false])
   })
@@ -343,7 +317,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("done"))
   })
 
@@ -356,7 +329,6 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("oops"))
   })
 
@@ -375,8 +347,22 @@ describe("useAsync", () => {
       </Async>
     )
     const { getByText } = render(component)
-    flushEffects()
     await waitForElement(() => getByText("outer undefined"))
     await waitForElement(() => getByText("outer inner"))
+  })
+
+  test("accepts [promiseFn, options] shorthand, with the former taking precedence", async () => {
+    const promiseFn1 = () => Promise.resolve("done")
+    const promiseFn2 = () => Promise.resolve("nope")
+    const Async = ({ children, ...props }) => children(useAsync(promiseFn1, props))
+    const onResolve = jest.fn()
+    const component = (
+      <Async promiseFn={promiseFn2} onResolve={onResolve}>
+        {({ data }) => data || null}
+      </Async>
+    )
+    const { getByText } = render(component)
+    await waitForElement(() => getByText("done"))
+    expect(onResolve).toHaveBeenCalledWith("done")
   })
 })

--- a/src/useAsync.spec.js
+++ b/src/useAsync.spec.js
@@ -160,9 +160,9 @@ describe("useAsync", () => {
     const props = { deferFn, foo: "bar" }
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining(props), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 1], expect.objectContaining(props), abortCtrl)
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining(props), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining(props), abortCtrl)
   })
 
   test("cancel will prevent the resolved promise from propagating and attempts to abort it", async () => {
@@ -198,11 +198,11 @@ describe("useAsync", () => {
     const { getByText } = render(component)
     expect(deferFn).not.toHaveBeenCalled()
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 1, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 1], expect.objectContaining({ deferFn }), abortCtrl)
     fireEvent.click(getByText("run"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining({ deferFn }), abortCtrl)
     fireEvent.click(getByText("reload"))
-    expect(deferFn).toHaveBeenCalledWith("go", 2, expect.objectContaining({ deferFn }), abortCtrl)
+    expect(deferFn).toHaveBeenCalledWith(["go", 2], expect.objectContaining({ deferFn }), abortCtrl)
   })
 
   test("only accepts the last invocation of the promise", async () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,8 +5,9 @@ type PromiseFn<T> = (props: object) => Promise<T>
 
 interface AsyncOptions<T> {
   promiseFn?: (props: object, controller: AbortController) => Promise<T>
-  deferFn?: (...args: any[]) => Promise<T>
+  deferFn?: (props: object, controller: AbortController, args: any[]) => Promise<T>
   watch?: any
+  watchFn?: (props: object, prevProps: object) => any
   initialValue?: T
   onResolve?: (data: T) => void
   onReject?: (error: Error) => void
@@ -17,9 +18,9 @@ interface AsyncProps<T> extends AsyncOptions<T> {
 }
 
 interface AsyncState<T> {
-  initialValue?: T
   data?: T
   error?: Error
+  initialValue?: T
   isLoading: boolean
   startedAt?: Date
   finishedAt?: Date
@@ -53,6 +54,9 @@ declare namespace Async {
 
 declare function createInstance<T>(defaultProps?: AsyncProps<T>): Async<T>
 
-export function useAsync<T>(opts: AsyncOptions<T> | PromiseFn<T>, init?: T): AsyncState<T>
+export function useAsync<T>(
+  arg1: AsyncOptions<T> | PromiseFn<T>,
+  arg2?: AsyncOptions<T>
+): AsyncState<T>
 
 export default createInstance

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -59,4 +59,15 @@ export function useAsync<T>(
   arg2?: AsyncOptions<T>
 ): AsyncState<T>
 
+interface FetchInit {
+  method?: string
+  headers?: Headers | object
+}
+
+export function useFetch<T>(
+  input: Request | string,
+  init?: FetchInit,
+  options?: AsyncOptions<T>
+): AsyncState<T>
+
 export default createInstance


### PR DESCRIPTION
This is a major update making `useAsync` the primary interface, stabilizing its API. It also adds the `useFetch` hook for more convenience working with HTTP requests. Furthermore there's several breaking changes: 

- `deferFn` now receives an `args` array as the first argument, instead of arguments to `run` being spread at the front of the arguments list. This enables better interop with TypeScript. You can use destructuring to keep using your existing variables.
- The shorthand version of `useAsync` now takes the `options` object as optional second argument. This used to be `initialValue`, but was undocumented and inflexible.