### PR TITLE
Updated TypeScript definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ import * as React from "react"
 type AsyncChildren<T> = ((state: AsyncState<T>) => React.ReactNode) | React.ReactNode
 type PromiseFn<T> = (props: object) => Promise<T>
 
-interface AsyncOptions<T> {
+export interface AsyncOptions<T> {
   promise?: Promise<T>
   promiseFn?: (props: object, controller: AbortController) => Promise<T>
   deferFn?: (args: any[], props: object, controller: AbortController) => Promise<T>
@@ -19,7 +19,7 @@ interface AsyncProps<T> extends AsyncOptions<T> {
   children?: AsyncChildren<T>
 }
 
-interface AsyncState<T> {
+export interface AsyncState<T> {
   data?: T
   error?: Error
   initialValue?: T


### PR DESCRIPTION
By exporting the `AsyncState` interface we allow users of the library to pass around the `AsyncState` without them having to duplicate the type in their own codebase. With the current type definitions it is not possible to type the parameter of a function to be of type `AsyncState`.