### PR TITLE
Update API to better match Promise spec and add the 'status' prop (closes #35)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
 cache:
   directories:
     - node_modules
-script: npm run test:compat
+script: npm run lint && npm run test:compat
 after_success:
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION

--- a/README.md
+++ b/README.md
@@ -382,7 +382,10 @@ is set to `"application/json"`.
 - `data` Last resolved promise value, maintained when new error arrives.
 - `error` Rejected promise reason, cleared when new data arrives.
 - `initialValue` The data or error that was provided through the `initialValue` prop.
-- `isLoading` Whether or not a Promise is currently pending.
+- `isPending` true when no promise has ever started, or one started but was cancelled.
+- `isLoading` true when a promise is currently awaiting settlement.
+- `isResolved` true when the last promise was fulfilled with a value.
+- `isRejected` true when the last promise was rejected with a reason.
 - `startedAt` When the current/last promise was started.
 - `finishedAt` When the last promise was resolved or rejected.
 - `counter` The number of times a promise was started.

--- a/README.md
+++ b/README.md
@@ -384,12 +384,12 @@ is set to `"application/json"`.
 - `initialValue` The data or error that was provided through the `initialValue` prop.
 - `startedAt` When the current/last promise was started.
 - `finishedAt` When the last promise was resolved or rejected.
-- `status` One of: `waiting`, `pending`, `fulfilled`, `rejected`.
-- `isWaiting` true when no promise has ever started, or one started but was cancelled.
+- `status` One of: `initial`, `pending`, `fulfilled`, `rejected`.
+- `isInitial` true when no promise has ever started, or one started but was cancelled.
 - `isPending` true when a promise is currently awaiting settlement. Alias: `isLoading`
 - `isFulfilled` true when the last promise was fulfilled with a value. Alias: `isResolved`
 - `isRejected` true when the last promise was rejected with a reason.
-- `isSettled` true when the last promise was fulfilled or rejected (not waiting or pending).
+- `isSettled` true when the last promise was fulfilled or rejected (not initial or pending).
 - `counter` The number of times a promise was started.
 - `cancel` Cancel any pending promise.
 - `run` Invokes the `deferFn`.
@@ -431,10 +431,10 @@ Tracks when the last promise was resolved or rejected.
 
 > `string`
 
-One of: `waiting`, `pending`, `fulfilled`, `rejected`.
+One of: `initial`, `pending`, `fulfilled`, `rejected`.
 These are available for import as `statusTypes`.
 
-#### `isWaiting`
+#### `isInitial`
 
 > `boolean`
 
@@ -466,7 +466,7 @@ Alias: `isResolved`
 
 > `boolean`
 
-`true` when the last promise was either fulfilled or rejected (i.e. not waiting or pending)
+`true` when the last promise was either fulfilled or rejected (i.e. not initial or pending)
 
 #### `counter`
 
@@ -511,7 +511,7 @@ invoked after the state update is completed. Returns the error to enable chainin
 React Async provides several helper components that make your JSX more declarative and less cluttered.
 They don't have to be direct children of `<Async>` and you can use the same component several times.
 
-### `<Async.Waiting>`
+### `<Async.Initial>`
 
 Renders only while the deferred promise is still waiting to be run, or you have not provided any promise.
 
@@ -524,14 +524,14 @@ Renders only while the deferred promise is still waiting to be run, or you have 
 
 ```js
 <Async deferFn={deferFn}>
-  <Async.Waiting>
+  <Async.Initial>
     <p>This text is only rendered while `run` has not yet been invoked on `deferFn`.</p>
-  </Async.Waiting>
+  </Async.Initial>
 </Async>
 ```
 
 ```js
-<Async.Waiting persist>
+<Async.Initial persist>
   {({ error, isLoading, run }) => (
     <div>
       <p>This text is only rendered while the promise has not resolved yet.</p>
@@ -541,7 +541,7 @@ Renders only while the deferred promise is still waiting to be run, or you have 
       {error && <p>{error.message}</p>}
     </div>
   )}
-</Async.Waiting>
+</Async.Initial>
 ```
 
 ### `<Async.Pending>`

--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ is set to `"application/json"`.
 - `finishedAt` When the last promise was resolved or rejected.
 - `status` One of: `waiting`, `pending`, `fulfilled`, `rejected`.
 - `isWaiting` true when no promise has ever started, or one started but was cancelled.
-- `isPending` true when a promise is currently awaiting settlement.
-- `isFulfilled` true when the last promise was fulfilled with a value.
+- `isPending` true when a promise is currently awaiting settlement. Alias: `isLoading`
+- `isFulfilled` true when the last promise was fulfilled with a value. Alias: `isResolved`
 - `isRejected` true when the last promise was rejected with a reason.
 - `isSettled` true when the last promise was fulfilled or rejected (not waiting or pending).
 - `counter` The number of times a promise was started.

--- a/README.md
+++ b/README.md
@@ -382,12 +382,14 @@ is set to `"application/json"`.
 - `data` Last resolved promise value, maintained when new error arrives.
 - `error` Rejected promise reason, cleared when new data arrives.
 - `initialValue` The data or error that was provided through the `initialValue` prop.
-- `isPending` true when no promise has ever started, or one started but was cancelled.
-- `isLoading` true when a promise is currently awaiting settlement.
-- `isResolved` true when the last promise was fulfilled with a value.
-- `isRejected` true when the last promise was rejected with a reason.
 - `startedAt` When the current/last promise was started.
 - `finishedAt` When the last promise was resolved or rejected.
+- `status` One of: `waiting`, `pending`, `fulfilled`, `rejected`.
+- `isWaiting` true when no promise has ever started, or one started but was cancelled.
+- `isPending` true when a promise is currently awaiting settlement.
+- `isFulfilled` true when the last promise was fulfilled with a value.
+- `isRejected` true when the last promise was rejected with a reason.
+- `isSettled` true when the last promise was fulfilled or rejected (not waiting or pending).
 - `counter` The number of times a promise was started.
 - `cancel` Cancel any pending promise.
 - `run` Invokes the `deferFn`.
@@ -413,12 +415,6 @@ Rejected promise reason, cleared when new data arrives.
 
 The data or error that was originally provided through the `initialValue` prop.
 
-#### `isLoading`
-
-> `boolean`
-
-`true` while a promise is pending, `false` otherwise.
-
 #### `startedAt`
 
 > `Date`
@@ -430,6 +426,47 @@ Tracks when the current/last promise was started.
 > `Date`
 
 Tracks when the last promise was resolved or rejected.
+
+#### `status`
+
+> `string`
+
+One of: `waiting`, `pending`, `fulfilled`, `rejected`.
+These are available for import as `statusTypes`.
+
+#### `isWaiting`
+
+> `boolean`
+
+`true` while no promise has started yet, or one was started but cancelled.
+
+#### `isPending`
+
+> `boolean`
+
+`true` while a promise is pending (loading), `false` otherwise.
+
+Alias: `isLoading`
+
+#### `isFulfilled`
+
+> `boolean`
+
+`true` when the last promise was fulfilled (resolved) with a value.
+
+Alias: `isResolved`
+
+#### `isRejected`
+
+> `boolean`
+
+`true` when the last promise was rejected with an error.
+
+#### `isSettled`
+
+> `boolean`
+
+`true` when the last promise was either fulfilled or rejected (i.e. not waiting or pending)
 
 #### `counter`
 
@@ -474,9 +511,44 @@ invoked after the state update is completed. Returns the error to enable chainin
 React Async provides several helper components that make your JSX more declarative and less cluttered.
 They don't have to be direct children of `<Async>` and you can use the same component several times.
 
-### `<Async.Loading>`
+### `<Async.Waiting>`
+
+Renders only while the deferred promise is still waiting to be run, or you have not provided any promise.
+
+#### Props
+
+- `persist` `boolean` Show until we have data, even while loading or when an error occurred. By default it hides as soon as the promise starts loading.
+- `children` `function(state: object): Node | Node` Render function or React Node.
+
+#### Examples
+
+```js
+<Async deferFn={deferFn}>
+  <Async.Waiting>
+    <p>This text is only rendered while `run` has not yet been invoked on `deferFn`.</p>
+  </Async.Waiting>
+</Async>
+```
+
+```js
+<Async.Waiting persist>
+  {({ error, isLoading, run }) => (
+    <div>
+      <p>This text is only rendered while the promise has not resolved yet.</p>
+      <button onClick={run} disabled={!isLoading}>
+        Run
+      </button>
+      {error && <p>{error.message}</p>}
+    </div>
+  )}
+</Async.Waiting>
+```
+
+### `<Async.Pending>`
 
 This component renders only while the promise is loading (unsettled).
+
+Alias: `<Async.Loading>`
 
 #### Props
 
@@ -486,18 +558,20 @@ This component renders only while the promise is loading (unsettled).
 #### Examples
 
 ```js
-<Async.Loading initial>
+<Async.Pending initial>
   <p>This text is only rendered while performing the initial load.</p>
-</Async.Loading>
+</Async.Pending>
 ```
 
 ```js
-<Async.Loading>{({ startedAt }) => `Loading since ${startedAt.toISOString()}`}</Async.Loading>
+<Async.Pending>{({ startedAt }) => `Loading since ${startedAt.toISOString()}`}</Async.Pending>
 ```
 
-### `<Async.Resolved>`
+### `<Async.Fulfilled>`
 
 This component renders only when the promise is fulfilled with data (`data !== undefined`).
+
+Alias: `<Async.Resolved>`
 
 #### Props
 
@@ -507,11 +581,11 @@ This component renders only when the promise is fulfilled with data (`data !== u
 #### Examples
 
 ```js
-<Async.Resolved persist>{data => <pre>{JSON.stringify(data)}</pre>}</Async.Resolved>
+<Async.Fulfilled persist>{data => <pre>{JSON.stringify(data)}</pre>}</Async.Fulfilled>
 ```
 
 ```js
-<Async.Resolved>{({ finishedAt }) => `Last updated ${startedAt.toISOString()}`}</Async.Resolved>
+<Async.Fulfilled>{({ finishedAt }) => `Last updated ${startedAt.toISOString()}`}</Async.Fulfilled>
 ```
 
 ### `<Async.Rejected>`
@@ -533,38 +607,14 @@ This component renders only when the promise is rejected.
 <Async.Rejected>{error => `Unexpected error: ${error.message}`}</Async.Rejected>
 ```
 
-### `<Async.Pending>`
+### `<Async.Settled>`
 
-Renders only while the deferred promise is still pending (not yet run), or you have not provided any promise.
+This component renders only when the promise is fulfilled or rejected.
 
 #### Props
 
-- `persist` `boolean` Show until we have data, even while loading or when an error occurred. By default it hides as soon as the promise starts loading.
+- `persist` `boolean` Show old data or error while loading new data. By default it hides as soon as a new promise starts.
 - `children` `function(state: object): Node | Node` Render function or React Node.
-
-#### Examples
-
-```js
-<Async deferFn={deferFn}>
-  <Async.Pending>
-    <p>This text is only rendered while `run` has not yet been invoked on `deferFn`.</p>
-  </Async.Pending>
-</Async>
-```
-
-```js
-<Async.Pending persist>
-  {({ error, isLoading, run }) => (
-    <div>
-      <p>This text is only rendered while the promise has not resolved yet.</p>
-      <button onClick={run} disabled={!isLoading}>
-        Run
-      </button>
-      {error && <p>{error.message}</p>}
-    </div>
-  )}
-</Async.Pending>
-```
 
 ## Usage examples
 

--- a/examples/basic-fetch/src/index.js
+++ b/examples/basic-fetch/src/index.js
@@ -27,8 +27,8 @@ const UserDetails = ({ data }) => (
 const App = () => (
   <>
     <Async promiseFn={loadUser} userId={1}>
-      {({ data, error, isLoading }) => {
-        if (isLoading) return <UserPlaceholder />
+      {({ data, error, isPending }) => {
+        if (isPending) return <UserPlaceholder />
         if (error) return <p>{error.message}</p>
         if (data) return <UserDetails data={data} />
         return null
@@ -36,10 +36,10 @@ const App = () => (
     </Async>
 
     <Async promiseFn={loadUser} userId={2}>
-      <Async.Loading>
+      <Async.Pending>
         <UserPlaceholder />
-      </Async.Loading>
-      <Async.Resolved>{data => <UserDetails data={data} />}</Async.Resolved>
+      </Async.Pending>
+      <Async.Fulfilled>{data => <UserDetails data={data} />}</Async.Fulfilled>
       <Async.Rejected>{error => <p>{error.message}</p>}</Async.Rejected>
     </Async>
   </>

--- a/examples/basic-hook/src/index.js
+++ b/examples/basic-hook/src/index.js
@@ -26,8 +26,8 @@ const UserDetails = ({ data }) => (
 )
 
 const User = ({ userId }) => {
-  const { data, error, isLoading } = useAsync({ promiseFn: loadUser, userId })
-  if (isLoading) return <UserPlaceholder />
+  const { data, error, isPending } = useAsync({ promiseFn: loadUser, userId })
+  if (isPending) return <UserPlaceholder />
   if (error) return <p>{error.message}</p>
   if (data) return <UserDetails data={data} />
   return null

--- a/examples/custom-instance/src/index.js
+++ b/examples/custom-instance/src/index.js
@@ -29,8 +29,8 @@ const UserDetails = ({ data }) => (
 const App = () => (
   <>
     <AsyncUser userId={1}>
-      {({ data, error, isLoading }) => {
-        if (isLoading) return <UserPlaceholder />
+      {({ data, error, isPending }) => {
+        if (isPending) return <UserPlaceholder />
         if (error) return <p>{error.message}</p>
         if (data) return <UserDetails data={data} />
         return null
@@ -38,10 +38,10 @@ const App = () => (
     </AsyncUser>
 
     <AsyncUser userId={2}>
-      <AsyncUser.Loading>
+      <AsyncUser.Pending>
         <UserPlaceholder />
-      </AsyncUser.Loading>
-      <AsyncUser.Resolved>{data => <UserDetails data={data} />}</AsyncUser.Resolved>
+      </AsyncUser.Pending>
+      <AsyncUser.Fulfilled>{data => <UserDetails data={data} />}</AsyncUser.Fulfilled>
       <AsyncUser.Rejected>{error => <p>{error.message}</p>}</AsyncUser.Rejected>
     </AsyncUser>
   </>

--- a/examples/movie-app/src/App.js
+++ b/examples/movie-app/src/App.js
@@ -62,14 +62,14 @@ const TopMovies = ({ handleSelect }) => (
       </span>
     </h1>
     <Async promiseFn={fetchMovies}>
-      <Async.Loading>
+      <Async.Pending>
         <p>Loading...</p>
-      </Async.Loading>
-      <Async.Resolved>
+      </Async.Pending>
+      <Async.Fulfilled>
         {movies =>
           movies.map(movie => <Movie {...movie} key={movie.id} onSelect={handleSelect(movie)} />)
         }
-      </Async.Resolved>
+      </Async.Fulfilled>
     </Async>
   </Fragment>
 )
@@ -99,10 +99,10 @@ const Details = ({ onBack, id }) => (
       </span>
     </button>
     <Async promiseFn={fetchMovieDetails} id={id} onResolve={console.log}>
-      <Async.Loading>
+      <Async.Pending>
         <p>Loading...</p>
-      </Async.Loading>
-      <Async.Resolved>
+      </Async.Pending>
+      <Async.Fulfilled>
         {movie => (
           <Fragment>
             <div className="main">
@@ -126,15 +126,15 @@ const Details = ({ onBack, id }) => (
             </div>
             <div className="reviews">
               <Async promiseFn={fetchMovieReviews} id={id} onResolve={console.log}>
-                <Async.Loading>
+                <Async.Pending>
                   <p>Loading...</p>
-                </Async.Loading>
-                <Async.Resolved>{reviews => reviews.map(Review)}</Async.Resolved>
+                </Async.Pending>
+                <Async.Fulfilled>{reviews => reviews.map(Review)}</Async.Fulfilled>
               </Async>
             </div>
           </Fragment>
         )}
-      </Async.Resolved>
+      </Async.Fulfilled>
     </Async>
   </div>
 )

--- a/examples/with-abortcontroller/src/index.js
+++ b/examples/with-abortcontroller/src/index.js
@@ -9,11 +9,11 @@ const download = (args, props, controller) =>
     .then(res => res.json())
 
 const App = () => {
-  const { run, cancel, isLoading } = useAsync({ deferFn: download })
+  const { run, cancel, isPending } = useAsync({ deferFn: download })
   return (
     <>
-      {isLoading ? <button onClick={cancel}>cancel</button> : <button onClick={run}>start</button>}
-      {isLoading ? (
+      {isPending ? <button onClick={cancel}>cancel</button> : <button onClick={run}>start</button>}
+      {isPending ? (
         <p>Loading...</p>
       ) : (
         <p>Inspect network traffic to see requests being canceled.</p>

--- a/examples/with-nextjs/pages/index.js
+++ b/examples/with-nextjs/pages/index.js
@@ -20,10 +20,10 @@ class Hello extends React.Component {
     const { userId = 1 } = url.query
     return (
       <Async promiseFn={loadUser} userId={userId} watch={userId} initialValue={data}>
-        <Async.Loading>
+        <Async.Pending>
           <p>Loading...</p>
-        </Async.Loading>
-        <Async.Resolved>
+        </Async.Pending>
+        <Async.Fulfilled>
           {data => (
             <>
               <p>
@@ -43,7 +43,7 @@ class Hello extends React.Component {
               </p>
             </>
           )}
-        </Async.Resolved>
+        </Async.Fulfilled>
         <i>
           This data is initially loaded server-side, then client-side when navigating prev/next.
         </i>

--- a/examples/with-react-router/js/Contributors.js
+++ b/examples/with-react-router/js/Contributors.js
@@ -1,7 +1,7 @@
 import React from "react"
 
-const Contributors = ({ data, error, isLoading }) => {
-  if (isLoading) return "Loading Contributers..."
+const Contributors = ({ data, error, isPending }) => {
+  if (isPending) return "Loading Contributers..."
   if (error) return "Error"
   return (
     <ul>

--- a/examples/with-react-router/js/Repositories.js
+++ b/examples/with-react-router/js/Repositories.js
@@ -1,7 +1,7 @@
 import React from "react"
 
-const Repositories = ({ data, error, isLoading }) => {
-  if (isLoading) return "Loading Repositories..."
+const Repositories = ({ data, error, isPending }) => {
+  if (isPending) return "Loading Repositories..."
   if (error) return "Error"
   return (
     <ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-async",
-  "version": "5.1.2",
+  "version": "6.0.0-0",
   "description": "React component for declarative promise resolution and data fetching",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -41,30 +41,30 @@
     "prop-types": ">=15.5.7"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-object-rest-spread": "7.3.4",
-    "@babel/plugin-transform-runtime": "7.2.0",
-    "@babel/preset-env": "7.3.4",
+    "@babel/plugin-proposal-object-rest-spread": "7.4.0",
+    "@babel/plugin-transform-runtime": "7.4.0",
+    "@babel/preset-env": "7.4.2",
     "@babel/preset-react": "7.0.0",
-    "@pika/pack": "0.3.5",
-    "@pika/plugin-build-node": "0.3.12",
-    "@pika/plugin-build-types": "0.3.12",
-    "@pika/plugin-build-web": "0.3.12",
-    "@pika/plugin-standard-pkg": "0.3.12",
+    "@pika/pack": "0.3.6",
+    "@pika/plugin-build-node": "0.3.14",
+    "@pika/plugin-build-types": "0.3.14",
+    "@pika/plugin-build-web": "0.3.14",
+    "@pika/plugin-standard-pkg": "0.3.14",
     "babel-eslint": "10.0.1",
-    "babel-jest": "24.3.1",
-    "eslint": "5.11.1",
-    "eslint-config-prettier": "3.3.0",
-    "eslint-plugin-jest": "22.3.0",
+    "babel-jest": "24.5.0",
+    "eslint": "5.15.3",
+    "eslint-config-prettier": "4.1.0",
+    "eslint-plugin-jest": "22.4.1",
     "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-promise": "4.0.1",
-    "eslint-plugin-react": "7.12.0",
-    "eslint-plugin-react-hooks": "1.0.1",
-    "jest": "24.3.1",
-    "jest-dom": "3.1.2",
-    "prettier": "1.15.3",
+    "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "1.6.0",
+    "jest": "24.5.0",
+    "jest-dom": "3.1.3",
+    "prettier": "1.16.4",
     "react": "16.8.1",
-    "react-dom": "16.8.1",
-    "react-testing-library": "5.5.3"
+    "react-dom": "16.8.5",
+    "react-testing-library": "6.0.3"
   },
   "jest": {
     "collectCoverage": true,
@@ -76,6 +76,7 @@
         "@pika/plugin-standard-pkg",
         {
           "exclude": [
+            "specs.js",
             "*.spec.js"
           ]
         }

--- a/src/Async.js
+++ b/src/Async.js
@@ -83,7 +83,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
         this.abortController = new window.AbortController()
       }
       this.counter++
-      this.dispatch({ type: actionTypes.start, meta: { counter: this.counter } })
+      this.mounted && this.dispatch({ type: actionTypes.start, meta: { counter: this.counter } })
     }
 
     load() {
@@ -118,7 +118,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
     cancel() {
       this.counter++
       this.abortController.abort()
-      this.dispatch({ type: actionTypes.cancel, meta: { counter: this.counter } })
+      this.mounted && this.dispatch({ type: actionTypes.cancel, meta: { counter: this.counter } })
     }
 
     onResolve(counter) {

--- a/src/Async.js
+++ b/src/Async.js
@@ -179,12 +179,12 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
   }
 
   /**
-   * Renders only when deferred promise is waiting (promise has not yet run).
+   * Renders only when no promise has started or completed yet.
    *
    * @prop {Function|Node} children Function (passing state) or React node
    * @prop {boolean} persist Show until we have data, even while pending (loading) or when an error occurred
    */
-  const Waiting = ({ children, persist }) => (
+  const Initial = ({ children, persist }) => (
     <Consumer>
       {state => {
         if (state.data !== undefined) return null
@@ -196,7 +196,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
   )
 
   if (PropTypes) {
-    Waiting.propTypes = {
+    Initial.propTypes = {
       children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
       persist: PropTypes.bool,
     }
@@ -281,7 +281,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
   const Settled = ({ children, persist }) => (
     <Consumer>
       {state => {
-        if (state.isWaiting) return null
+        if (state.isInitial) return null
         if (state.isPending && !persist) return null
         return isFunction(children) ? children(state) : children || null
       }}
@@ -295,14 +295,14 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
     }
   }
 
-  Waiting.displayName = `${displayName}.Waiting`
+  Initial.displayName = `${displayName}.Initial`
   Pending.displayName = `${displayName}.Pending`
   Fulfilled.displayName = `${displayName}.Fulfilled`
   Rejected.displayName = `${displayName}.Rejected`
   Settled.displayName = `${displayName}.Settled`
 
   Async.displayName = displayName
-  Async.Waiting = Waiting
+  Async.Initial = Initial
   Async.Pending = Pending
   Async.Loading = Pending // alias
   Async.Fulfilled = Fulfilled

--- a/src/Async.spec.js
+++ b/src/Async.spec.js
@@ -31,20 +31,20 @@ describe("Async", () => {
     let two
     const { rerender } = render(
       <Async>
-        <Async.Pending>
+        <Async.Waiting>
           {value => {
             one = value
           }}
-        </Async.Pending>
+        </Async.Waiting>
       </Async>
     )
     rerender(
       <Async someProp>
-        <Async.Pending>
+        <Async.Waiting>
           {value => {
             two = value
           }}
-        </Async.Pending>
+        </Async.Waiting>
       </Async>
     )
     expect(one).toBe(two)
@@ -100,52 +100,52 @@ describe("Async.Resolved", () => {
         <Async.Resolved>
           {outer => (
             <Async promiseFn={inner}>
-              <Async.Loading>{outer} loading</Async.Loading>
+              <Async.Pending>{outer} pending</Async.Pending>
               <Async.Resolved>{inner => outer + " " + inner}</Async.Resolved>
             </Async>
           )}
         </Async.Resolved>
       </Async>
     )
-    expect(queryByText("outer loading")).toBeNull()
-    await waitForElement(() => getByText("outer loading"))
+    expect(queryByText("outer pending")).toBeNull()
+    await waitForElement(() => getByText("outer pending"))
     expect(queryByText("outer inner")).toBeNull()
     await waitForElement(() => getByText("outer inner"))
     expect(queryByText("outer inner")).toBeInTheDocument()
   })
 })
 
-describe("Async.Loading", () => {
-  test("renders only while the promise is loading", async () => {
+describe("Async.Pending", () => {
+  test("renders only while the promise is pending", async () => {
     const promiseFn = () => resolveTo("ok")
     const { getByText, queryByText } = render(
       <Async promiseFn={promiseFn}>
-        <Async.Loading>loading</Async.Loading>
-        <Async.Resolved>done</Async.Resolved>
-      </Async>
-    )
-    expect(queryByText("loading")).toBeInTheDocument()
-    await waitForElement(() => getByText("done"))
-    expect(queryByText("loading")).toBeNull()
-  })
-})
-
-describe("Async.Pending", () => {
-  test("renders only while the deferred promise is pending", async () => {
-    const deferFn = () => resolveTo("ok")
-    const { getByText, queryByText } = render(
-      <Async deferFn={deferFn}>
-        <Async.Pending>{({ run }) => <button onClick={run}>pending</button>}</Async.Pending>
-        <Async.Loading>loading</Async.Loading>
+        <Async.Pending>pending</Async.Pending>
         <Async.Resolved>done</Async.Resolved>
       </Async>
     )
     expect(queryByText("pending")).toBeInTheDocument()
-    fireEvent.click(getByText("pending"))
-    expect(queryByText("pending")).toBeNull()
-    expect(queryByText("loading")).toBeInTheDocument()
     await waitForElement(() => getByText("done"))
-    expect(queryByText("loading")).toBeNull()
+    expect(queryByText("pending")).toBeNull()
+  })
+})
+
+describe("Async.Waiting", () => {
+  test("renders only while the deferred promise is waiting", async () => {
+    const deferFn = () => resolveTo("ok")
+    const { getByText, queryByText } = render(
+      <Async deferFn={deferFn}>
+        <Async.Waiting>{({ run }) => <button onClick={run}>waiting</button>}</Async.Waiting>
+        <Async.Pending>pending</Async.Pending>
+        <Async.Resolved>done</Async.Resolved>
+      </Async>
+    )
+    expect(queryByText("waiting")).toBeInTheDocument()
+    fireEvent.click(getByText("waiting"))
+    expect(queryByText("waiting")).toBeNull()
+    expect(queryByText("pending")).toBeInTheDocument()
+    await waitForElement(() => getByText("done"))
+    expect(queryByText("pending")).toBeNull()
   })
 })
 
@@ -190,11 +190,11 @@ describe("createInstance", () => {
     const CustomAsync = createInstance({ promiseFn })
     const { getByText } = render(
       <CustomAsync>
-        <CustomAsync.Loading>loading</CustomAsync.Loading>
+        <CustomAsync.Pending>pending</CustomAsync.Pending>
         <CustomAsync.Resolved>resolved</CustomAsync.Resolved>
       </CustomAsync>
     )
-    await waitForElement(() => getByText("loading"))
+    await waitForElement(() => getByText("pending"))
     await waitForElement(() => getByText("resolved"))
   })
 

--- a/src/Async.spec.js
+++ b/src/Async.spec.js
@@ -51,13 +51,15 @@ describe("Async", () => {
   })
 })
 
-describe("Async.Resolved", () => {
+describe("Async.Fulfilled", () => {
   test("renders only after the promise is resolved", async () => {
     const promiseFn = () => resolveTo("ok")
     const deferFn = () => rejectTo("fail")
     const { getByText, queryByText } = render(
       <Async promiseFn={promiseFn} deferFn={deferFn}>
-        <Async.Resolved>{(data, { run }) => <button onClick={run}>{data}</button>}</Async.Resolved>
+        <Async.Fulfilled>
+          {(data, { run }) => <button onClick={run}>{data}</button>}
+        </Async.Fulfilled>
         <Async.Rejected>{error => error}</Async.Rejected>
       </Async>
     )
@@ -76,9 +78,9 @@ describe("Async.Resolved", () => {
     const deferFn = () => rejectTo("fail")
     const { getByText, queryByText } = render(
       <Async promiseFn={promiseFn} deferFn={deferFn}>
-        <Async.Resolved persist>
+        <Async.Fulfilled persist>
           {(data, { run }) => <button onClick={run}>{data}</button>}
-        </Async.Resolved>
+        </Async.Fulfilled>
         <Async.Rejected>{error => error}</Async.Rejected>
       </Async>
     )
@@ -92,19 +94,19 @@ describe("Async.Resolved", () => {
     expect(queryByText("fail")).toBeInTheDocument()
   })
 
-  test("Async.Resolved works also with nested Async", async () => {
+  test("Async.Fulfilled works also with nested Async", async () => {
     const outer = () => resolveIn(0)("outer")
     const inner = () => resolveIn(100)("inner")
     const { getByText, queryByText } = render(
       <Async promiseFn={outer}>
-        <Async.Resolved>
+        <Async.Fulfilled>
           {outer => (
             <Async promiseFn={inner}>
               <Async.Pending>{outer} pending</Async.Pending>
-              <Async.Resolved>{inner => outer + " " + inner}</Async.Resolved>
+              <Async.Fulfilled>{inner => outer + " " + inner}</Async.Fulfilled>
             </Async>
           )}
-        </Async.Resolved>
+        </Async.Fulfilled>
       </Async>
     )
     expect(queryByText("outer pending")).toBeNull()
@@ -121,7 +123,7 @@ describe("Async.Pending", () => {
     const { getByText, queryByText } = render(
       <Async promiseFn={promiseFn}>
         <Async.Pending>pending</Async.Pending>
-        <Async.Resolved>done</Async.Resolved>
+        <Async.Fulfilled>done</Async.Fulfilled>
       </Async>
     )
     expect(queryByText("pending")).toBeInTheDocument()
@@ -137,7 +139,7 @@ describe("Async.Waiting", () => {
       <Async deferFn={deferFn}>
         <Async.Waiting>{({ run }) => <button onClick={run}>waiting</button>}</Async.Waiting>
         <Async.Pending>pending</Async.Pending>
-        <Async.Resolved>done</Async.Resolved>
+        <Async.Fulfilled>done</Async.Fulfilled>
       </Async>
     )
     expect(queryByText("waiting")).toBeInTheDocument()
@@ -155,6 +157,32 @@ describe("Async.Rejected", () => {
     const { getByText, queryByText } = render(
       <Async promiseFn={promiseFn}>
         <Async.Rejected>{err => err}</Async.Rejected>
+      </Async>
+    )
+    expect(queryByText("err")).toBeNull()
+    await waitForElement(() => getByText("err"))
+    expect(queryByText("err")).toBeInTheDocument()
+  })
+})
+
+describe("Async.Settled", () => {
+  test("renders after the promise is fulfilled", async () => {
+    const promiseFn = () => resolveTo("value")
+    const { getByText, queryByText } = render(
+      <Async promiseFn={promiseFn}>
+        <Async.Settled>{({ data }) => data}</Async.Settled>
+      </Async>
+    )
+    expect(queryByText("value")).toBeNull()
+    await waitForElement(() => getByText("value"))
+    expect(queryByText("value")).toBeInTheDocument()
+  })
+
+  test("renders after the promise is rejected", async () => {
+    const promiseFn = () => rejectTo("err")
+    const { getByText, queryByText } = render(
+      <Async promiseFn={promiseFn}>
+        <Async.Settled>{({ error }) => error}</Async.Settled>
       </Async>
     )
     expect(queryByText("err")).toBeNull()
@@ -191,7 +219,7 @@ describe("createInstance", () => {
     const { getByText } = render(
       <CustomAsync>
         <CustomAsync.Pending>pending</CustomAsync.Pending>
-        <CustomAsync.Resolved>resolved</CustomAsync.Resolved>
+        <CustomAsync.Fulfilled>resolved</CustomAsync.Fulfilled>
       </CustomAsync>
     )
     await waitForElement(() => getByText("pending"))

--- a/src/Async.spec.js
+++ b/src/Async.spec.js
@@ -31,20 +31,20 @@ describe("Async", () => {
     let two
     const { rerender } = render(
       <Async>
-        <Async.Waiting>
+        <Async.Initial>
           {value => {
             one = value
           }}
-        </Async.Waiting>
+        </Async.Initial>
       </Async>
     )
     rerender(
       <Async someProp>
-        <Async.Waiting>
+        <Async.Initial>
           {value => {
             two = value
           }}
-        </Async.Waiting>
+        </Async.Initial>
       </Async>
     )
     expect(one).toBe(two)
@@ -132,19 +132,19 @@ describe("Async.Pending", () => {
   })
 })
 
-describe("Async.Waiting", () => {
-  test("renders only while the deferred promise is waiting", async () => {
+describe("Async.Initial", () => {
+  test("renders only while the deferred promise has not started yet", async () => {
     const deferFn = () => resolveTo("ok")
     const { getByText, queryByText } = render(
       <Async deferFn={deferFn}>
-        <Async.Waiting>{({ run }) => <button onClick={run}>waiting</button>}</Async.Waiting>
+        <Async.Initial>{({ run }) => <button onClick={run}>initial</button>}</Async.Initial>
         <Async.Pending>pending</Async.Pending>
         <Async.Fulfilled>done</Async.Fulfilled>
       </Async>
     )
-    expect(queryByText("waiting")).toBeInTheDocument()
-    fireEvent.click(getByText("waiting"))
-    expect(queryByText("waiting")).toBeNull()
+    expect(queryByText("initial")).toBeInTheDocument()
+    fireEvent.click(getByText("initial"))
+    expect(queryByText("initial")).toBeNull()
     expect(queryByText("pending")).toBeInTheDocument()
     await waitForElement(() => getByText("done"))
     expect(queryByText("pending")).toBeNull()

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,13 +30,13 @@ interface AbstractState<T> {
   setError: (error: Error, callback?: () => void) => Error
 }
 
-export type AsyncWaiting<T> = AbstractState<T> & {
+export type AsyncInitial<T> = AbstractState<T> & {
   data: undefined
   error: undefined
   startedAt: undefined
   finishedAt: undefined
-  status: "waiting"
-  isWaiting: false
+  status: "initial"
+  isInitial: false
   isPending: false
   isLoading: false
   isFulfilled: false
@@ -50,7 +50,7 @@ export type AsyncPending<T> = AbstractState<T> & {
   startedAt: Date
   finishedAt: undefined
   status: "pending"
-  isWaiting: false
+  isInitial: false
   isPending: true
   isLoading: true
   isFulfilled: false
@@ -64,7 +64,7 @@ export type AsyncFulfilled<T> = AbstractState<T> & {
   startedAt: Date
   finishedAt: Date
   status: "fulfilled"
-  isWaiting: false
+  isInitial: false
   isPending: false
   isLoading: false
   isFulfilled: true
@@ -78,7 +78,7 @@ export type AsyncRejected<T> = AbstractState<T> & {
   startedAt: Date
   finishedAt: Date
   status: "rejected"
-  isWaiting: false
+  isInitial: false
   isPending: false
   isLoading: false
   isFulfilled: false
@@ -86,12 +86,12 @@ export type AsyncRejected<T> = AbstractState<T> & {
   isRejected: true
   isSettled: true
 }
-export type AsyncState<T> = AsyncWaiting<T> | AsyncPending<T> | AsyncFulfilled<T> | AsyncRejected<T>
+export type AsyncState<T> = AsyncInitial<T> | AsyncPending<T> | AsyncFulfilled<T> | AsyncRejected<T>
 
 declare class Async<T> extends React.Component<AsyncProps<T>, AsyncState<T>> {}
 
 declare namespace Async {
-  export function Waiting<T>(props: {
+  export function Initial<T>(props: {
     children?: AsyncChildren<T>
     persist?: boolean
   }): React.ReactNode

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,11 +21,7 @@ export interface AsyncProps<T> extends AsyncOptions<T> {
 }
 
 interface AbstractState<T> {
-  data?: T
-  error?: Error
   initialValue?: T
-  startedAt?: Date
-  finishedAt?: Date
   isWaiting: boolean
   isPending: boolean
   isLoading: boolean
@@ -41,10 +37,34 @@ interface AbstractState<T> {
   setError: (error: Error, callback?: () => void) => Error
 }
 
-export type AsyncWaiting<T> = AbstractState<T> & { status: "waiting" }
-export type AsyncPending<T> = AbstractState<T> & { status: "pending" }
-export type AsyncFulfilled<T> = AbstractState<T> & { status: "fulfilled"; data: T }
-export type AsyncRejected<T> = AbstractState<T> & { status: "rejected"; error: Error }
+export type AsyncWaiting<T> = AbstractState<T> & {
+  status: "waiting"
+  data: undefined
+  error: undefined
+  startedAt: undefined
+  finishedAt: undefined
+}
+export type AsyncPending<T> = AbstractState<T> & {
+  status: "pending"
+  data?: T
+  error?: Error
+  startedAt: Date
+  finishedAt: undefined
+}
+export type AsyncFulfilled<T> = AbstractState<T> & {
+  status: "fulfilled"
+  data: T
+  error: undefined
+  startedAt: Date
+  finishedAt: Date
+}
+export type AsyncRejected<T> = AbstractState<T> & {
+  status: "rejected"
+  data?: T
+  error: Error
+  startedAt: Date
+  finishedAt: Date
+}
 export type AsyncState<T> = AsyncWaiting<T> | AsyncPending<T> | AsyncFulfilled<T> | AsyncRejected<T>
 
 declare class Async<T> extends React.Component<AsyncProps<T>, AsyncState<T>> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,8 +45,8 @@ export type AsyncWaiting<T> = AbstractState<T> & {
   isSettled: false
 }
 export type AsyncPending<T> = AbstractState<T> & {
-  data?: T
-  error?: Error
+  data: T | undefined
+  error: Error | undefined
   startedAt: Date
   finishedAt: undefined
   status: "pending"
@@ -73,7 +73,7 @@ export type AsyncFulfilled<T> = AbstractState<T> & {
   isSettled: true
 }
 export type AsyncRejected<T> = AbstractState<T> & {
-  data?: T
+  data: T | undefined
   error: Error
   startedAt: Date
   finishedAt: Date

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,7 @@ interface AbstractState<T> {
   isPending: boolean
   isLoading: boolean
   isFulfilled: boolean
+  isResolved: boolean
   isRejected: boolean
   isSettled: boolean
   counter: number
@@ -57,11 +58,23 @@ declare namespace Async {
     children?: AsyncChildren<T>
     initial?: boolean
   }): React.ReactNode
+  export function Loading<T>(props: {
+    children?: AsyncChildren<T>
+    initial?: boolean
+  }): React.ReactNode
+  export function Fulfilled<T>(props: {
+    children?: AsyncChildren<T>
+    persist?: boolean
+  }): React.ReactNode
   export function Resolved<T>(props: {
     children?: AsyncChildren<T>
     persist?: boolean
   }): React.ReactNode
   export function Rejected<T>(props: {
+    children?: AsyncChildren<T>
+    persist?: boolean
+  }): React.ReactNode
+  export function Settled<T>(props: {
     children?: AsyncChildren<T>
     persist?: boolean
   }): React.ReactNode

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,13 +20,16 @@ export interface AsyncProps<T> extends AsyncOptions<T> {
   children?: AsyncChildren<T>
 }
 
-export interface AsyncState<T> {
+interface AbstractState<T> {
   data?: T
   error?: Error
   initialValue?: T
-  isLoading: boolean
   startedAt?: Date
   finishedAt?: Date
+  isPending: boolean
+  isLoading: boolean
+  isFulfilled: boolean
+  isRejected: boolean
   counter: number
   cancel: () => void
   run: (...args: any[]) => Promise<T>
@@ -34,6 +37,12 @@ export interface AsyncState<T> {
   setData: (data: T, callback?: () => void) => T
   setError: (error: Error, callback?: () => void) => Error
 }
+
+export type AsyncPending<T> = AbstractState<T> & { status: "pending" }
+export type AsyncLoading<T> = AbstractState<T> & { status: "loading" }
+export type AsyncFulfilled<T> = AbstractState<T> & { status: "fulfilled"; data: T }
+export type AsyncRejected<T> = AbstractState<T> & { status: "rejected"; error: Error }
+export type AsyncState<T> = AsyncPending<T> | AsyncLoading<T> | AsyncFulfilled<T> | AsyncRejected<T>
 
 declare class Async<T> extends React.Component<AsyncProps<T>, AsyncState<T>> {}
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,13 +22,6 @@ export interface AsyncProps<T> extends AsyncOptions<T> {
 
 interface AbstractState<T> {
   initialValue?: T
-  isWaiting: boolean
-  isPending: boolean
-  isLoading: boolean
-  isFulfilled: boolean
-  isResolved: boolean
-  isRejected: boolean
-  isSettled: boolean
   counter: number
   cancel: () => void
   run: (...args: any[]) => Promise<T>
@@ -38,32 +31,60 @@ interface AbstractState<T> {
 }
 
 export type AsyncWaiting<T> = AbstractState<T> & {
-  status: "waiting"
   data: undefined
   error: undefined
   startedAt: undefined
   finishedAt: undefined
+  status: "waiting"
+  isWaiting: false
+  isPending: false
+  isLoading: false
+  isFulfilled: false
+  isResolved: false
+  isRejected: false
+  isSettled: false
 }
 export type AsyncPending<T> = AbstractState<T> & {
-  status: "pending"
   data?: T
   error?: Error
   startedAt: Date
   finishedAt: undefined
+  status: "pending"
+  isWaiting: false
+  isPending: true
+  isLoading: true
+  isFulfilled: false
+  isResolved: false
+  isRejected: false
+  isSettled: false
 }
 export type AsyncFulfilled<T> = AbstractState<T> & {
-  status: "fulfilled"
   data: T
   error: undefined
   startedAt: Date
   finishedAt: Date
+  status: "fulfilled"
+  isWaiting: false
+  isPending: false
+  isLoading: false
+  isFulfilled: true
+  isResolved: true
+  isRejected: false
+  isSettled: true
 }
 export type AsyncRejected<T> = AbstractState<T> & {
-  status: "rejected"
   data?: T
   error: Error
   startedAt: Date
   finishedAt: Date
+  status: "rejected"
+  isWaiting: false
+  isPending: false
+  isLoading: false
+  isFulfilled: false
+  isResolved: false
+  isRejected: true
+  isSettled: true
 }
 export type AsyncState<T> = AsyncWaiting<T> | AsyncPending<T> | AsyncFulfilled<T> | AsyncRejected<T>
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,10 +26,12 @@ interface AbstractState<T> {
   initialValue?: T
   startedAt?: Date
   finishedAt?: Date
+  isWaiting: boolean
   isPending: boolean
   isLoading: boolean
   isFulfilled: boolean
   isRejected: boolean
+  isSettled: boolean
   counter: number
   cancel: () => void
   run: (...args: any[]) => Promise<T>
@@ -38,20 +40,20 @@ interface AbstractState<T> {
   setError: (error: Error, callback?: () => void) => Error
 }
 
+export type AsyncWaiting<T> = AbstractState<T> & { status: "waiting" }
 export type AsyncPending<T> = AbstractState<T> & { status: "pending" }
-export type AsyncLoading<T> = AbstractState<T> & { status: "loading" }
 export type AsyncFulfilled<T> = AbstractState<T> & { status: "fulfilled"; data: T }
 export type AsyncRejected<T> = AbstractState<T> & { status: "rejected"; error: Error }
-export type AsyncState<T> = AsyncPending<T> | AsyncLoading<T> | AsyncFulfilled<T> | AsyncRejected<T>
+export type AsyncState<T> = AsyncWaiting<T> | AsyncPending<T> | AsyncFulfilled<T> | AsyncRejected<T>
 
 declare class Async<T> extends React.Component<AsyncProps<T>, AsyncState<T>> {}
 
 declare namespace Async {
-  export function Pending<T>(props: {
+  export function Waiting<T>(props: {
     children?: AsyncChildren<T>
     persist?: boolean
   }): React.ReactNode
-  export function Loading<T>(props: {
+  export function Pending<T>(props: {
     children?: AsyncChildren<T>
     initial?: boolean
   }): React.ReactNode

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ import Async from "./Async"
 export { createInstance } from "./Async"
 export { default as useAsync, useFetch } from "./useAsync"
 export default Async
+export { statusTypes } from "./status"

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,3 +1,5 @@
+import { getInitialStatus, getIdleStatus, getStatusProps, statusTypes } from "./status"
+
 export const actionTypes = {
   start: "start",
   cancel: "cancel",
@@ -9,9 +11,9 @@ export const init = ({ initialValue, promise, promiseFn }) => ({
   initialValue,
   data: initialValue instanceof Error ? undefined : initialValue,
   error: initialValue instanceof Error ? initialValue : undefined,
-  isLoading: !!promise || (promiseFn && !initialValue),
   startedAt: promise || promiseFn ? new Date() : undefined,
   finishedAt: initialValue ? new Date() : undefined,
+  ...getStatusProps(getInitialStatus(initialValue, promise || promiseFn)),
   counter: 0,
 })
 
@@ -20,16 +22,16 @@ export const reducer = (state, { type, payload, meta }) => {
     case actionTypes.start:
       return {
         ...state,
-        isLoading: true,
         startedAt: new Date(),
         finishedAt: undefined,
+        ...getStatusProps(statusTypes.loading),
         counter: meta.counter,
       }
     case actionTypes.cancel:
       return {
         ...state,
-        isLoading: false,
         startedAt: undefined,
+        ...getStatusProps(getIdleStatus(state.error || state.data)),
         counter: meta.counter,
       }
     case actionTypes.fulfill:
@@ -37,15 +39,15 @@ export const reducer = (state, { type, payload, meta }) => {
         ...state,
         data: payload,
         error: undefined,
-        isLoading: false,
         finishedAt: new Date(),
+        ...getStatusProps(statusTypes.fulfilled),
       }
     case actionTypes.reject:
       return {
         ...state,
         error: payload,
-        isLoading: false,
         finishedAt: new Date(),
+        ...getStatusProps(statusTypes.rejected),
       }
   }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -24,7 +24,7 @@ export const reducer = (state, { type, payload, meta }) => {
         ...state,
         startedAt: new Date(),
         finishedAt: undefined,
-        ...getStatusProps(statusTypes.loading),
+        ...getStatusProps(statusTypes.pending),
         counter: meta.counter,
       }
     case actionTypes.cancel:

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -31,6 +31,7 @@ export const reducer = (state, { type, payload, meta }) => {
       return {
         ...state,
         startedAt: undefined,
+        finishedAt: undefined,
         ...getStatusProps(getIdleStatus(state.error || state.data)),
         counter: meta.counter,
       }

--- a/src/specs.js
+++ b/src/specs.js
@@ -17,9 +17,14 @@ export const common = Async => () => {
           expect(renderProps).toHaveProperty("data")
           expect(renderProps).toHaveProperty("error")
           expect(renderProps).toHaveProperty("initialValue")
-          expect(renderProps).toHaveProperty("isLoading")
           expect(renderProps).toHaveProperty("startedAt")
           expect(renderProps).toHaveProperty("finishedAt")
+          expect(renderProps).toHaveProperty("isWaiting")
+          expect(renderProps).toHaveProperty("isPending")
+          expect(renderProps).toHaveProperty("isLoading")
+          expect(renderProps).toHaveProperty("isFulfilled")
+          expect(renderProps).toHaveProperty("isRejected")
+          expect(renderProps).toHaveProperty("isSettled")
           expect(renderProps).toHaveProperty("counter")
           expect(renderProps).toHaveProperty("cancel")
           expect(renderProps).toHaveProperty("run")
@@ -310,8 +315,8 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
     const states = []
     const { getByText } = render(
       <Async promiseFn={promiseFn} initialValue="done">
-        {({ data, isLoading }) => {
-          states.push(isLoading)
+        {({ data, isPending }) => {
+          states.push(isPending)
           return data || null
         }}
       </Async>

--- a/src/specs.js
+++ b/src/specs.js
@@ -19,7 +19,7 @@ export const common = Async => () => {
           expect(renderProps).toHaveProperty("initialValue")
           expect(renderProps).toHaveProperty("startedAt")
           expect(renderProps).toHaveProperty("finishedAt")
-          expect(renderProps).toHaveProperty("isWaiting")
+          expect(renderProps).toHaveProperty("isInitial")
           expect(renderProps).toHaveProperty("isPending")
           expect(renderProps).toHaveProperty("isLoading")
           expect(renderProps).toHaveProperty("isFulfilled")

--- a/src/status.js
+++ b/src/status.js
@@ -1,5 +1,5 @@
 export const statusTypes = {
-  waiting: "waiting",
+  initial: "initial",
   pending: "pending",
   fulfilled: "fulfilled",
   rejected: "rejected",
@@ -9,18 +9,18 @@ export const getInitialStatus = (value, promise) => {
   if (value instanceof Error) return statusTypes.rejected
   if (value !== undefined) return statusTypes.fulfilled
   if (promise) return statusTypes.pending
-  return statusTypes.waiting
+  return statusTypes.initial
 }
 
 export const getIdleStatus = value => {
   if (value instanceof Error) return statusTypes.rejected
   if (value !== undefined) return statusTypes.fulfilled
-  return statusTypes.waiting
+  return statusTypes.initial
 }
 
 export const getStatusProps = status => ({
   status,
-  isWaiting: status === statusTypes.waiting,
+  isInitial: status === statusTypes.initial,
   isPending: status === statusTypes.pending,
   isLoading: status === statusTypes.pending, // alias
   isFulfilled: status === statusTypes.fulfilled,

--- a/src/status.js
+++ b/src/status.js
@@ -1,0 +1,27 @@
+export const statusTypes = {
+  pending: "pending",
+  loading: "loading",
+  fulfilled: "fulfilled",
+  rejected: "rejected",
+}
+
+export const getInitialStatus = (value, promise) => {
+  if (value instanceof Error) return statusTypes.rejected
+  if (value !== undefined) return statusTypes.fulfilled
+  if (promise) return statusTypes.loading
+  return statusTypes.pending
+}
+
+export const getIdleStatus = value => {
+  if (value instanceof Error) return statusTypes.rejected
+  if (value !== undefined) return statusTypes.fulfilled
+  return statusTypes.pending
+}
+
+export const getStatusProps = status => ({
+  status,
+  isPending: status === statusTypes.pending,
+  isLoading: status === statusTypes.loading,
+  isFulfilled: status === statusTypes.fulfilled,
+  isRejected: status === statusTypes.rejected,
+})

--- a/src/status.js
+++ b/src/status.js
@@ -1,6 +1,6 @@
 export const statusTypes = {
+  waiting: "waiting",
   pending: "pending",
-  loading: "loading",
   fulfilled: "fulfilled",
   rejected: "rejected",
 }
@@ -8,20 +8,23 @@ export const statusTypes = {
 export const getInitialStatus = (value, promise) => {
   if (value instanceof Error) return statusTypes.rejected
   if (value !== undefined) return statusTypes.fulfilled
-  if (promise) return statusTypes.loading
-  return statusTypes.pending
+  if (promise) return statusTypes.pending
+  return statusTypes.waiting
 }
 
 export const getIdleStatus = value => {
   if (value instanceof Error) return statusTypes.rejected
   if (value !== undefined) return statusTypes.fulfilled
-  return statusTypes.pending
+  return statusTypes.waiting
 }
 
 export const getStatusProps = status => ({
   status,
+  isWaiting: status === statusTypes.waiting,
   isPending: status === statusTypes.pending,
-  isLoading: status === statusTypes.loading,
+  isLoading: status === statusTypes.pending, // alias
   isFulfilled: status === statusTypes.fulfilled,
+  isResolved: status === statusTypes.fulfilled, // alias
   isRejected: status === statusTypes.rejected,
+  isSettled: status === statusTypes.fulfilled || status === statusTypes.rejected,
 })

--- a/src/status.spec.js
+++ b/src/status.spec.js
@@ -1,0 +1,32 @@
+/* eslint-disable react/prop-types */
+
+import "jest-dom/extend-expect"
+
+import { getInitialStatus, getIdleStatus, statusTypes } from "./status"
+
+describe("getInitialStatus", () => {
+  test("returns 'pending' when given an undefined value", () => {
+    expect(getInitialStatus(undefined)).toEqual(statusTypes.pending)
+  })
+  test("returns 'loading' when given only a promise", () => {
+    expect(getInitialStatus(undefined, Promise.resolve("foo"))).toEqual(statusTypes.loading)
+  })
+  test("returns 'rejected' when given an Error value", () => {
+    expect(getInitialStatus(new Error("oops"))).toEqual(statusTypes.rejected)
+  })
+  test("returns 'fulfilled' when given any other value", () => {
+    expect(getInitialStatus(null)).toEqual(statusTypes.fulfilled)
+  })
+})
+
+describe("getIdleStatus", () => {
+  test("returns 'pending' when given an undefined value", () => {
+    expect(getIdleStatus(undefined)).toEqual(statusTypes.pending)
+  })
+  test("returns 'rejected' when given an Error value", () => {
+    expect(getIdleStatus(new Error("oops"))).toEqual(statusTypes.rejected)
+  })
+  test("returns 'fulfilled' when given any other value", () => {
+    expect(getIdleStatus(null)).toEqual(statusTypes.fulfilled)
+  })
+})

--- a/src/status.spec.js
+++ b/src/status.spec.js
@@ -5,8 +5,8 @@ import "jest-dom/extend-expect"
 import { getInitialStatus, getIdleStatus, statusTypes } from "./status"
 
 describe("getInitialStatus", () => {
-  test("returns 'waiting' when given an undefined value", () => {
-    expect(getInitialStatus(undefined)).toEqual(statusTypes.waiting)
+  test("returns 'initial' when given an undefined value", () => {
+    expect(getInitialStatus(undefined)).toEqual(statusTypes.initial)
   })
   test("returns 'pending' when given only a promise", () => {
     expect(getInitialStatus(undefined, Promise.resolve("foo"))).toEqual(statusTypes.pending)
@@ -20,8 +20,8 @@ describe("getInitialStatus", () => {
 })
 
 describe("getIdleStatus", () => {
-  test("returns 'waiting' when given an undefined value", () => {
-    expect(getIdleStatus(undefined)).toEqual(statusTypes.waiting)
+  test("returns 'initial' when given an undefined value", () => {
+    expect(getIdleStatus(undefined)).toEqual(statusTypes.initial)
   })
   test("returns 'rejected' when given an Error value", () => {
     expect(getIdleStatus(new Error("oops"))).toEqual(statusTypes.rejected)

--- a/src/status.spec.js
+++ b/src/status.spec.js
@@ -5,11 +5,11 @@ import "jest-dom/extend-expect"
 import { getInitialStatus, getIdleStatus, statusTypes } from "./status"
 
 describe("getInitialStatus", () => {
-  test("returns 'pending' when given an undefined value", () => {
-    expect(getInitialStatus(undefined)).toEqual(statusTypes.pending)
+  test("returns 'waiting' when given an undefined value", () => {
+    expect(getInitialStatus(undefined)).toEqual(statusTypes.waiting)
   })
-  test("returns 'loading' when given only a promise", () => {
-    expect(getInitialStatus(undefined, Promise.resolve("foo"))).toEqual(statusTypes.loading)
+  test("returns 'pending' when given only a promise", () => {
+    expect(getInitialStatus(undefined, Promise.resolve("foo"))).toEqual(statusTypes.pending)
   })
   test("returns 'rejected' when given an Error value", () => {
     expect(getInitialStatus(new Error("oops"))).toEqual(statusTypes.rejected)
@@ -20,8 +20,8 @@ describe("getInitialStatus", () => {
 })
 
 describe("getIdleStatus", () => {
-  test("returns 'pending' when given an undefined value", () => {
-    expect(getIdleStatus(undefined)).toEqual(statusTypes.pending)
+  test("returns 'waiting' when given an undefined value", () => {
+    expect(getIdleStatus(undefined)).toEqual(statusTypes.waiting)
   })
   test("returns 'rejected' when given an Error value", () => {
     expect(getIdleStatus(new Error("oops"))).toEqual(statusTypes.rejected)

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -81,12 +81,9 @@ const useAsync = (arg1, arg2) => {
   useEffect(() => {
     if (watchFn && prevOptions.current && watchFn(options, prevOptions.current)) load()
   })
-  useEffect(
-    () => {
-      promise || promiseFn ? load() : cancel()
-    },
-    [promise, promiseFn, watch]
-  )
+  useEffect(() => {
+    promise || promiseFn ? load() : cancel()
+  }, [promise, promiseFn, watch])
   useEffect(() => () => (isMounted.current = false), [])
   useEffect(() => () => abortController.current.abort(), [])
   useEffect(() => (prevOptions.current = options) && undefined)

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -42,7 +42,7 @@ const useAsync = (arg1, arg2) => {
       abortController.current = new window.AbortController()
     }
     counter.current++
-    dispatch({ type: actionTypes.start, meta: { counter: counter.current } })
+    isMounted.current && dispatch({ type: actionTypes.start, meta: { counter: counter.current } })
   }
 
   const load = () => {
@@ -75,7 +75,7 @@ const useAsync = (arg1, arg2) => {
   const cancel = () => {
     counter.current++
     abortController.current.abort()
-    dispatch({ type: actionTypes.cancel, meta: { counter: counter.current } })
+    isMounted.current && dispatch({ type: actionTypes.cancel, meta: { counter: counter.current } })
   }
 
   useEffect(() => {
@@ -91,18 +91,14 @@ const useAsync = (arg1, arg2) => {
   useEffect(() => () => abortController.current.abort(), [])
   useEffect(() => (prevOptions.current = options) && undefined)
 
-  useDebugValue(state, ({ startedAt, finishedAt, error }) => {
-    if (startedAt && (!finishedAt || finishedAt < startedAt)) return `[${counter.current}] Loading`
-    if (finishedAt) return error ? `[${counter.current}] Rejected` : `[${counter.current}] Resolved`
-    return `[${counter.current}] Pending`
-  })
+  useDebugValue(state, ({ status }) => `[${counter.current}] ${status}`)
 
   return useMemo(
     () => ({
       ...state,
+      cancel,
       run,
       reload: () => (lastArgs.current ? run(...lastArgs.current) : load()),
-      cancel,
       setData,
       setError,
     }),
@@ -131,11 +127,7 @@ const useAsyncFetch = (input, init, { defer, json, ...options } = {}) => {
       [JSON.stringify(input), JSON.stringify(init)]
     ),
   })
-  useDebugValue(state, ({ startedAt, finishedAt, error, counter }) => {
-    if (startedAt && (!finishedAt || finishedAt < startedAt)) return `[${counter}] Loading`
-    if (finishedAt) return error ? `[${counter}] Rejected` : `[${counter}] Resolved`
-    return `[${counter}] Pending`
-  })
+  useDebugValue(state, ({ counter, status }) => `[${counter}] ${status}`)
   return state
 }
 


### PR DESCRIPTION
+ **Breaking change**: `Async.Pending` was renamed to `Async.Waiting`
+ Added the `status` prop, which can be one of `initial`, `pending`, `fulfilled` or `rejected`
+ Added `isInitial`, `isPending`, `isFulfilled` (with alias `isResolved`), `isRejected` and `isSettled` boolean props. `isLoading` is now an alias for `isPending`.
+ Added separate TypeScript types for each status, to make various props non-optional.

The `pending` and `fulfilled` statuses were chosen over `loading` and `resolved` because they better match the [terminology in the Promise specification](https://github.com/domenic/promises-unwrapping/blob/master/docs/states-and-fates.md#readme). The `Pending` helper component was renamed to `Initial` accordingly, causing a breaking change.