### PR TITLE
Allow control over internal state using a state reducer and dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ These can be passed in an object to `useAsync()`, or as props to `<Async>` and c
 - `initialValue` Provide initial data or error for server-side rendering.
 - `onResolve` Callback invoked when Promise resolves.
 - `onReject` Callback invoked when Promise rejects.
+- `reducer` State reducer to control internal state updates.
+- `dispatcher` Action dispatcher to control internal action dispatching.
 
 `useFetch` additionally takes these options:
 
@@ -370,6 +372,21 @@ Callback function invoked when a promise resolves, receives data as argument.
 > `function(reason: Error): void`
 
 Callback function invoked when a promise rejects, receives rejection reason (error) as argument.
+
+#### `reducer`
+
+> `function(state: any, action: Object, internalReducer: function(state: any, action: Object))`
+
+State reducer to take full control over state updates by wrapping the internal reducer. It receives the current state,
+the dispatched action and the internal reducer. You probably want to invoke the internal reducer at some point.
+
+#### `dispatcher`
+
+> `function(action: Object, internalDispatch: function(action: Object), props: Object)`
+
+Action dispatcher to take full control over action dispatching by wrapping the internal dispatcher. It receives the
+original action, the internal dispatcher and all component props (or options). You probably want to invoke the internal
+dispatcher at some point.
 
 #### `defer`
 
@@ -602,7 +619,9 @@ Alias: `<Async.Resolved>`
 ```
 
 ```jsx
-<Async.Fulfilled>{(data, { finishedAt }) => `Last updated ${finishedAt.toISOString()}`}</Async.Fulfilled>
+<Async.Fulfilled>
+  {(data, { finishedAt }) => `Last updated ${finishedAt.toISOString()}`}
+</Async.Fulfilled>
 ```
 
 ### `<Async.Rejected>`

--- a/src/Async.js
+++ b/src/Async.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { actionTypes, init, reducer as asyncReducer } from "./reducer"
+import { actionTypes, init, dispatchMiddleware, reducer as asyncReducer } from "./reducer"
 
 let PropTypes
 try {
@@ -55,8 +55,9 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       const reducer = _reducer
         ? (state, action) => _reducer(state, action, asyncReducer)
         : asyncReducer
-      const dispatch = (action, callback) =>
+      const dispatch = dispatchMiddleware((action, callback) => {
         this.setState(state => reducer(state, action), callback)
+      })
       this.dispatch = _dispatcher ? action => _dispatcher(action, dispatch, props) : dispatch
     }
 
@@ -87,26 +88,38 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       this.mounted = false
     }
 
-    start() {
+    getMeta(meta) {
+      return {
+        counter: this.counter,
+        ...meta,
+      }
+    }
+
+    start(promiseFn) {
       if ("AbortController" in window) {
         this.abortController.abort()
         this.abortController = new window.AbortController()
       }
       this.counter++
-      this.mounted && this.dispatch({ type: actionTypes.start, meta: { counter: this.counter } })
+      return new Promise((resolve, reject) => {
+        if (!this.mounted) return
+        const executor = () => promiseFn().then(resolve, reject)
+        this.dispatch({ type: actionTypes.start, payload: executor, meta: this.getMeta() })
+      })
     }
 
     load() {
       const promise = this.props.promise
       if (promise) {
-        this.start()
-        return promise.then(this.onResolve(this.counter), this.onReject(this.counter))
+        return this.start(() => promise).then(
+          this.onResolve(this.counter),
+          this.onReject(this.counter)
+        )
       }
-
       const promiseFn = this.props.promiseFn || defaultProps.promiseFn
       if (promiseFn) {
-        this.start()
-        return promiseFn(this.props, this.abortController).then(
+        const props = { ...defaultProps, ...this.props }
+        return this.start(() => promiseFn(props, this.abortController)).then(
           this.onResolve(this.counter),
           this.onReject(this.counter)
         )
@@ -117,8 +130,8 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       const deferFn = this.props.deferFn || defaultProps.deferFn
       if (deferFn) {
         this.args = args
-        this.start()
-        return deferFn(args, { ...defaultProps, ...this.props }, this.abortController).then(
+        const props = { ...defaultProps, ...this.props }
+        return this.start(() => deferFn(args, props, this.abortController)).then(
           this.onResolve(this.counter),
           this.onReject(this.counter)
         )
@@ -128,7 +141,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
     cancel() {
       this.counter++
       this.abortController.abort()
-      this.mounted && this.dispatch({ type: actionTypes.cancel, meta: { counter: this.counter } })
+      this.mounted && this.dispatch({ type: actionTypes.cancel, meta: this.getMeta() })
     }
 
     onResolve(counter) {
@@ -152,13 +165,17 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
     }
 
     setData(data, callback) {
-      this.mounted && this.dispatch({ type: actionTypes.fulfill, payload: data }, callback)
+      this.mounted &&
+        this.dispatch({ type: actionTypes.fulfill, payload: data, meta: this.getMeta() }, callback)
       return data
     }
 
     setError(error, callback) {
       this.mounted &&
-        this.dispatch({ type: actionTypes.reject, payload: error, error: true }, callback)
+        this.dispatch(
+          { type: actionTypes.reject, payload: error, error: true, meta: this.getMeta() },
+          callback
+        )
       return error
     }
 

--- a/src/Async.js
+++ b/src/Async.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { actionTypes, init, reducer } from "./reducer"
+import { actionTypes, init, reducer as asyncReducer } from "./reducer"
 
 let PropTypes
 try {
@@ -49,7 +49,15 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
         setData: this.setData,
         setError: this.setError,
       }
-      this.dispatch = (action, callback) => this.setState(state => reducer(state, action), callback)
+
+      const _reducer = props.reducer || defaultProps.reducer
+      const _dispatcher = props.dispatcher || defaultProps.dispatcher
+      const reducer = _reducer
+        ? (state, action) => _reducer(state, action, asyncReducer)
+        : asyncReducer
+      const dispatch = (action, callback) =>
+        this.setState(state => reducer(state, action), callback)
+      this.dispatch = _dispatcher ? action => _dispatcher(action, dispatch, props) : dispatch
     }
 
     componentDidMount() {
@@ -177,6 +185,8 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       initialValue: PropTypes.any,
       onResolve: PropTypes.func,
       onReject: PropTypes.func,
+      reducer: PropTypes.func,
+      dispatcher: PropTypes.func,
     }
   }
 

--- a/src/Async.spec.js
+++ b/src/Async.spec.js
@@ -12,6 +12,8 @@ import {
   withPromise,
   withPromiseFn,
   withDeferFn,
+  withReducer,
+  withDispatcher,
 } from "./specs"
 
 const abortCtrl = { abort: jest.fn() }
@@ -25,6 +27,8 @@ describe("Async", () => {
   describe("with `promise`", withPromise(Async, abortCtrl))
   describe("with `promiseFn`", withPromiseFn(Async, abortCtrl))
   describe("with `deferFn`", withDeferFn(Async, abortCtrl))
+  describe("with `reducer`", withReducer(Async, abortCtrl))
+  describe("with `dispatcher`", withDispatcher(Async, abortCtrl))
 
   test("an unrelated change in props does not update the Context", async () => {
     let one

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -57,3 +57,10 @@ export const reducer = (state, { type, payload, meta }) => {
       return state
   }
 }
+
+export const dispatchMiddleware = dispatch => (action, ...args) => {
+  dispatch(action, ...args)
+  if (action.type === actionTypes.start && typeof action.payload === "function") {
+    action.payload()
+  }
+}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -53,5 +53,7 @@ export const reducer = (state, { type, payload, meta }) => {
         finishedAt: new Date(),
         ...getStatusProps(statusTypes.rejected),
       }
+    default:
+      return state
   }
 }

--- a/src/specs.js
+++ b/src/specs.js
@@ -417,7 +417,7 @@ export const withDeferFn = (Async, abortCtrl) => () => {
 }
 
 export const withReducer = Async => () => {
-  test.only("receives state, action and the original reducer", async () => {
+  test("receives state, action and the original reducer", async () => {
     const promise = resolveTo("done")
     const reducer = jest.fn((state, action, asyncReducer) => asyncReducer(state, action))
     const { getByText } = render(
@@ -433,7 +433,7 @@ export const withReducer = Async => () => {
     )
   })
 
-  test.only("allows overriding state updates", async () => {
+  test("allows overriding state updates", async () => {
     const promise = resolveTo("done")
     const reducer = (state, action, asyncReducer) => {
       if (action.type === "fulfill") action.payload = "cool"
@@ -449,7 +449,7 @@ export const withReducer = Async => () => {
 }
 
 export const withDispatcher = Async => () => {
-  test.only("receives action, the original dispatch method and options", async () => {
+  test("receives action, the original dispatch method and options", async () => {
     const promise = resolveTo("done")
     const dispatcher = jest.fn((action, dispatch) => dispatch(action))
     const props = { promise, dispatcher }
@@ -462,7 +462,7 @@ export const withDispatcher = Async => () => {
     )
   })
 
-  test.only("allows overriding actions before dispatch", async () => {
+  test("allows overriding actions before dispatch", async () => {
     const promise = resolveTo("done")
     const dispatcher = (action, dispatch) => {
       if (action.type === "fulfill") action.payload = "cool"
@@ -476,7 +476,7 @@ export const withDispatcher = Async => () => {
     await waitForElement(() => getByText("cool"))
   })
 
-  test.only("allows dispatching additional actions", async () => {
+  test("allows dispatching additional actions", async () => {
     const promise = resolveTo("done")
     const customAction = { type: "custom" }
     const dispatcher = (action, dispatch) => {

--- a/src/specs.js
+++ b/src/specs.js
@@ -9,6 +9,7 @@ export const resolveTo = resolveIn(0)
 export const rejectIn = ms => err =>
   new Promise((resolve, reject) => setTimeout(reject, ms, new Error(err)))
 export const rejectTo = rejectIn(0)
+export const sleep = ms => resolveIn(ms)()
 
 export const common = Async => () => {
   test("passes `data`, `error`, metadata and methods as render props", async () => {
@@ -99,14 +100,14 @@ export const withPromise = Async => () => {
   test("invokes `onResolve` callback when the promise resolves", async () => {
     const onResolve = jest.fn()
     render(<Async promise={resolveTo("ok")} onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).toHaveBeenCalledWith("ok")
   })
 
   test("invokes `onReject` callback when the promise rejects", async () => {
     const onReject = jest.fn()
     render(<Async promise={rejectTo("err")} onReject={onReject} />)
-    await resolveTo()
+    await sleep(10)
     expect(onReject).toHaveBeenCalledWith(new Error("err"))
   })
 
@@ -114,7 +115,7 @@ export const withPromise = Async => () => {
     const onResolve = jest.fn()
     const { unmount } = render(<Async promise={resolveTo("ok")} onResolve={onResolve} />)
     unmount()
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalled()
   })
 
@@ -124,7 +125,7 @@ export const withPromise = Async => () => {
     const onResolve = jest.fn()
     const { rerender } = render(<Async promise={promise1} onResolve={onResolve} />)
     rerender(<Async promise={promise2} onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalledWith("one")
     expect(onResolve).toHaveBeenCalledWith("two")
   })
@@ -133,7 +134,7 @@ export const withPromise = Async => () => {
     const onResolve = jest.fn()
     const { rerender } = render(<Async promise={resolveTo()} onResolve={onResolve} />)
     rerender(<Async onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalled()
   })
 
@@ -191,14 +192,14 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
   test("invokes `onResolve` callback when the promise resolves", async () => {
     const onResolve = jest.fn()
     render(<Async promiseFn={() => resolveTo("ok")} onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).toHaveBeenCalledWith("ok")
   })
 
   test("invokes `onReject` callback when the promise rejects", async () => {
     const onReject = jest.fn()
     render(<Async promiseFn={() => rejectTo("err")} onReject={onReject} />)
-    await resolveTo()
+    await sleep(10)
     expect(onReject).toHaveBeenCalledWith(new Error("err"))
   })
 
@@ -280,7 +281,7 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
     const onResolve = jest.fn()
     const { unmount } = render(<Async promiseFn={() => resolveTo("ok")} onResolve={onResolve} />)
     unmount()
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalled()
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
   })
@@ -291,7 +292,7 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
     const onResolve = jest.fn()
     const { rerender } = render(<Async promiseFn={promiseFn1} onResolve={onResolve} />)
     rerender(<Async promiseFn={promiseFn2} onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalledWith("one")
     expect(onResolve).toHaveBeenCalledWith("two")
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
@@ -301,7 +302,7 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
     const onResolve = jest.fn()
     const { rerender } = render(<Async promiseFn={() => resolveTo()} onResolve={onResolve} />)
     rerender(<Async onResolve={onResolve} />)
-    await resolveTo()
+    await sleep(10)
     expect(onResolve).not.toHaveBeenCalled()
     expect(abortCtrl.abort).toHaveBeenCalledTimes(1)
   })
@@ -309,7 +310,7 @@ export const withPromiseFn = (Async, abortCtrl) => () => {
   test("does not run `promiseFn` on mount when `initialValue` is provided", async () => {
     const promiseFn = jest.fn().mockReturnValue(resolveTo())
     render(<Async promiseFn={promiseFn} initialValue={{}} />)
-    await resolveTo()
+    await sleep(10)
     expect(promiseFn).not.toHaveBeenCalled()
   })
 

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -1,5 +1,5 @@
 import { useCallback, useDebugValue, useEffect, useMemo, useRef, useReducer } from "react"
-import { actionTypes, init, reducer } from "./reducer"
+import { actionTypes, init, reducer as asyncReducer } from "./reducer"
 
 const noop = () => {}
 
@@ -12,7 +12,13 @@ const useAsync = (arg1, arg2) => {
   const prevOptions = useRef(undefined)
   const abortController = useRef({ abort: noop })
 
-  const [state, dispatch] = useReducer(reducer, options, init)
+  const { reducer, dispatcher } = options
+  const [state, _dispatch] = useReducer(
+    reducer ? (state, action) => reducer(state, action, asyncReducer) : asyncReducer,
+    options,
+    init
+  )
+  const dispatch = dispatcher ? action => dispatcher(action, _dispatch, options) : _dispatch
 
   const setData = (data, callback = noop) => {
     if (isMounted.current) {
@@ -101,7 +107,7 @@ const useAsync = (arg1, arg2) => {
       setData,
       setError,
     }),
-    [state, deferFn, onResolve, onReject]
+    [state, deferFn, onResolve, onReject, dispatcher, reducer]
   )
 }
 

--- a/src/useAsync.js
+++ b/src/useAsync.js
@@ -1,5 +1,5 @@
 import { useCallback, useDebugValue, useEffect, useMemo, useRef, useReducer } from "react"
-import { actionTypes, init, reducer as asyncReducer } from "./reducer"
+import { actionTypes, init, dispatchMiddleware, reducer as asyncReducer } from "./reducer"
 
 const noop = () => {}
 
@@ -18,11 +18,15 @@ const useAsync = (arg1, arg2) => {
     options,
     init
   )
-  const dispatch = dispatcher ? action => dispatcher(action, _dispatch, options) : _dispatch
+  const dispatch = dispatcher
+    ? action => dispatcher(action, dispatchMiddleware(_dispatch), options)
+    : dispatchMiddleware(_dispatch)
+
+  const getMeta = meta => ({ counter: counter.current, ...meta })
 
   const setData = (data, callback = noop) => {
     if (isMounted.current) {
-      dispatch({ type: actionTypes.fulfill, payload: data })
+      dispatch({ type: actionTypes.fulfill, payload: data, meta: getMeta() })
       callback()
     }
     return data
@@ -30,19 +34,10 @@ const useAsync = (arg1, arg2) => {
 
   const setError = (error, callback = noop) => {
     if (isMounted.current) {
-      dispatch({ type: actionTypes.reject, payload: error, error: true })
+      dispatch({ type: actionTypes.reject, payload: error, error: true, meta: getMeta() })
       callback()
     }
     return error
-  }
-
-  const start = () => {
-    if ("AbortController" in window) {
-      abortController.current.abort()
-      abortController.current = new window.AbortController()
-    }
-    counter.current++
-    isMounted.current && dispatch({ type: actionTypes.start, meta: { counter: counter.current } })
   }
 
   const { onResolve, onReject } = options
@@ -51,16 +46,30 @@ const useAsync = (arg1, arg2) => {
   const handleReject = count => error =>
     count === counter.current && setError(error, () => onReject && onReject(error))
 
+  const start = promiseFn => {
+    if ("AbortController" in window) {
+      abortController.current.abort()
+      abortController.current = new window.AbortController()
+    }
+    counter.current++
+    return new Promise((resolve, reject) => {
+      if (!isMounted.current) return
+      const executor = () => promiseFn().then(resolve, reject)
+      dispatch({ type: actionTypes.start, payload: executor, meta: getMeta() })
+    })
+  }
+
   const { promise, promiseFn, initialValue } = options
   const load = () => {
     if (promise) {
-      start()
-      return promise.then(handleResolve(counter.current), handleReject(counter.current))
+      return start(() => promise).then(
+        handleResolve(counter.current),
+        handleReject(counter.current)
+      )
     }
     const isPreInitialized = initialValue && counter.current === 0
     if (promiseFn && !isPreInitialized) {
-      start()
-      return promiseFn(options, abortController.current).then(
+      return start(() => promiseFn(options, abortController.current)).then(
         handleResolve(counter.current),
         handleReject(counter.current)
       )
@@ -71,8 +80,7 @@ const useAsync = (arg1, arg2) => {
   const run = (...args) => {
     if (deferFn) {
       lastArgs.current = args
-      start()
-      return deferFn(args, options, abortController.current).then(
+      return start(() => deferFn(args, options, abortController.current)).then(
         handleResolve(counter.current),
         handleReject(counter.current)
       )
@@ -82,7 +90,7 @@ const useAsync = (arg1, arg2) => {
   const cancel = () => {
     counter.current++
     abortController.current.abort()
-    isMounted.current && dispatch({ type: actionTypes.cancel, meta: { counter: counter.current } })
+    isMounted.current && dispatch({ type: actionTypes.cancel, meta: getMeta() })
   }
 
   const { watch, watchFn } = options

--- a/src/useAsync.spec.js
+++ b/src/useAsync.spec.js
@@ -5,6 +5,7 @@ import React from "react"
 import { render, fireEvent, cleanup, waitForElement } from "react-testing-library"
 import { useAsync, useFetch } from "./index"
 import {
+  sleep,
   resolveTo,
   common,
   withPromise,
@@ -76,10 +77,10 @@ describe("useAsync", () => {
     const { getByText } = render(<App />)
     expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 0 }), abortCtrl)
     fireEvent.click(getByText("inc"))
-    await resolveTo() // resolve promiseFn
+    await sleep(10) // resolve promiseFn
     expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
     fireEvent.click(getByText("run"))
-    await resolveTo() // resolve deferFn
+    await sleep(10) // resolve deferFn
     expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
   })
 })

--- a/src/useAsync.spec.js
+++ b/src/useAsync.spec.js
@@ -4,7 +4,15 @@ import "jest-dom/extend-expect"
 import React from "react"
 import { render, fireEvent, cleanup, waitForElement } from "react-testing-library"
 import { useAsync, useFetch } from "./index"
-import { resolveTo, common, withPromise, withPromiseFn, withDeferFn } from "./specs"
+import {
+  resolveTo,
+  common,
+  withPromise,
+  withPromiseFn,
+  withDeferFn,
+  withReducer,
+  withDispatcher,
+} from "./specs"
 
 const abortCtrl = { abort: jest.fn(), signal: "SIGNAL" }
 window.AbortController = jest.fn(() => abortCtrl)
@@ -26,6 +34,8 @@ describe("useAsync", () => {
   describe("with `promise`", withPromise(Async, abortCtrl))
   describe("with `promiseFn`", withPromiseFn(Async, abortCtrl))
   describe("with `deferFn`", withDeferFn(Async, abortCtrl))
+  describe("with `reducer`", withReducer(Async, abortCtrl))
+  describe("with `dispatcher`", withDispatcher(Async, abortCtrl))
 
   test("accepts [promiseFn, options] shorthand, with the former taking precedence", async () => {
     const promiseFn1 = () => resolveTo("done")


### PR DESCRIPTION
This adds two new props/options: `reducer` and `dispatcher`. These wrap the internal reducer and dispatcher to allow full control over React Async's internal state management. It also makes invocation of the `promiseFn` / `deferFn` part of the dispatched action so it can be delayed, cached or scheduled.

This work is in preparation for #44.