### PR TITLE
test: fix arguments

### DIFF
--- a/src/Async.spec.js
+++ b/src/Async.spec.js
@@ -23,12 +23,12 @@ beforeEach(abortCtrl.abort.mockClear)
 afterEach(cleanup)
 
 describe("Async", () => {
-  describe("common", common(Async, abortCtrl))
-  describe("with `promise`", withPromise(Async, abortCtrl))
+  describe("common", common(Async))
+  describe("with `promise`", withPromise(Async))
   describe("with `promiseFn`", withPromiseFn(Async, abortCtrl))
   describe("with `deferFn`", withDeferFn(Async, abortCtrl))
-  describe("with `reducer`", withReducer(Async, abortCtrl))
-  describe("with `dispatcher`", withDispatcher(Async, abortCtrl))
+  describe("with `reducer`", withReducer(Async))
+  describe("with `dispatcher`", withDispatcher(Async))
 
   test("an unrelated change in props does not update the Context", async () => {
     let one

--- a/src/useAsync.spec.js
+++ b/src/useAsync.spec.js
@@ -31,12 +31,12 @@ const Fetch = ({ children = () => null, input, init, options }) =>
   children(useFetch(input, init, options))
 
 describe("useAsync", () => {
-  describe("common", common(Async, abortCtrl))
-  describe("with `promise`", withPromise(Async, abortCtrl))
+  describe("common", common(Async))
+  describe("with `promise`", withPromise(Async))
   describe("with `promiseFn`", withPromiseFn(Async, abortCtrl))
   describe("with `deferFn`", withDeferFn(Async, abortCtrl))
-  describe("with `reducer`", withReducer(Async, abortCtrl))
-  describe("with `dispatcher`", withDispatcher(Async, abortCtrl))
+  describe("with `reducer`", withReducer(Async))
+  describe("with `dispatcher`", withDispatcher(Async))
 
   test("accepts [promiseFn, options] shorthand, with the former taking precedence", async () => {
     const promiseFn1 = () => resolveTo("done")


### PR DESCRIPTION
# Description
This PR fixes the arguments of the following functions which are expecting only 1 argument:
-`common`
-`withPromise`
-`withReducer`
-`withDispatcher`

## Breaking changes
None

# Checklist
Make sure you check all the boxes. You can omit items that are not applicable.

- [x] Implementation for both `<Async>` and `useAsync()`
- [x] Added / updated the unit tests
- [x] Added / updated the documentation
- [x] Updated the PropTypes
- [x] Updated the TypeScript type definitions
