### PR TITLE
Fix default export for types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -146,7 +146,7 @@ declare namespace Async {
   }): React.ReactNode
 }
 
-declare function createInstance<T>(defaultProps?: AsyncProps<T>): Async<T>
+export function createInstance<T>(defaultProps?: AsyncProps<T>): Async<T>
 
 export function useAsync<T>(
   arg1: AsyncOptions<T> | PromiseFn<T>,
@@ -164,4 +164,4 @@ export function useFetch<T>(
   options?: FetchOptions<T>
 ): AsyncState<T>
 
-export default createInstance
+export default Async


### PR DESCRIPTION
# Description

Presently the createInstance() function is the default export for the TypeScript types. I believe this should be the Async class instead. The createInstance() function should be a regular export.

This will probably resolve issue https://github.com/ghengeveld/react-async/issues/54

# Checklist

Make sure you check all the boxes. You can omit items that are not applicable.

- [x ] Updated the TypeScript type definitions