### PR TITLE
Feat reinitialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ is set to `"application/json"`.
 - `cancel` Cancel any pending promise.
 - `run` Invokes the `deferFn`.
 - `reload` Re-runs the promise when invoked, using any previous arguments.
-- `reinitialize` Reinitializes the state as `initial`.
+- `reinitialize` Reset the component as if it was destroyed and recreated
 - `setData` Sets `data` to the passed value, unsets `error` and cancels any pending promise.
 - `setError` Sets `error` to the passed value and cancels any pending promise.
 
@@ -593,7 +593,7 @@ Re-runs the promise when invoked, using the previous arguments.
 
 > `function(): void`
 
-Reinitializes the state as `initial`.
+Reset the component as if it was destroyed and recreated.
 
 #### `setData`
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ is set to `"application/json"`.
 - `cancel` Cancel any pending promise.
 - `run` Invokes the `deferFn`.
 - `reload` Re-runs the promise when invoked, using any previous arguments.
+- `reinitialize` Reinitializes the state as `initial`.
 - `setData` Sets `data` to the passed value, unsets `error` and cancels any pending promise.
 - `setError` Sets `error` to the passed value and cancels any pending promise.
 
@@ -587,6 +588,12 @@ Runs the `deferFn`, passing any arguments provided as an array.
 > `function(): void`
 
 Re-runs the promise when invoked, using the previous arguments.
+
+#### `reinitialize`
+
+> `function(): void`
+
+Reinitializes the state as `initial`.
 
 #### `setData`
 

--- a/packages/react-async/src/Async.js
+++ b/packages/react-async/src/Async.js
@@ -22,6 +22,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       this.load = this.load.bind(this)
       this.run = this.run.bind(this)
       this.cancel = this.cancel.bind(this)
+      this.reinitialize = this.reinitialize.bind(this)
       this.onResolve = this.onResolve.bind(this)
       this.onReject = this.onReject.bind(this)
       this.setData = this.setData.bind(this)
@@ -43,6 +44,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
           this.load()
           this.run(...this.args)
         },
+        reinitialize: this.reinitialize,
         setData: this.setData,
         setError: this.setError,
       }
@@ -152,6 +154,11 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       this.counter++
       this.abortController.abort()
       this.mounted && this.dispatch({ type: actionTypes.cancel, meta: this.getMeta() })
+    }
+
+    reinitialize() {
+      this.mounted &&
+        this.dispatch({ type: actionTypes.reinitialize, meta: this.getMeta(), payload: this.props })
     }
 
     onResolve(counter) {

--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -47,6 +47,7 @@ interface AbstractState<T> {
   cancel: () => void
   run: (...args: any[]) => Promise<T>
   reload: () => void
+  reinitialize: () => void
   setData: (data: T, callback?: () => void) => T
   setError: (error: Error, callback?: () => void) => Error
 }

--- a/packages/react-async/src/propTypes.js
+++ b/packages/react-async/src/propTypes.js
@@ -25,6 +25,7 @@ const stateObject =
     cancel: PropTypes.func,
     run: PropTypes.func,
     reload: PropTypes.func,
+    reinitialize: PropTypes.func,
     setData: PropTypes.func,
     setError: PropTypes.func,
   })

--- a/packages/react-async/src/reducer.js
+++ b/packages/react-async/src/reducer.js
@@ -5,6 +5,7 @@ export const actionTypes = {
   cancel: "cancel",
   fulfill: "fulfill",
   reject: "reject",
+  reinitialize: "reinitialize",
 }
 
 export const init = ({ initialValue, promise, promiseFn }) => ({
@@ -52,6 +53,13 @@ export const reducer = (state, { type, payload, meta }) => {
         value: payload,
         finishedAt: new Date(),
         ...getStatusProps(statusTypes.rejected),
+      }
+    case actionTypes.reinitialize:
+      return {
+        ...init(payload),
+        startedAt: undefined,
+        finishedAt: undefined,
+        ...getStatusProps(statusTypes.initial),
       }
     default:
       return state

--- a/packages/react-async/src/reducer.js
+++ b/packages/react-async/src/reducer.js
@@ -55,12 +55,10 @@ export const reducer = (state, { type, payload, meta }) => {
         ...getStatusProps(statusTypes.rejected),
       }
     case actionTypes.reinitialize:
-      return {
-        ...init(payload),
-        startedAt: undefined,
-        finishedAt: undefined,
-        ...getStatusProps(statusTypes.initial),
-      }
+      const newState = init(payload)
+      if (payload.initialValue) newState.finishedAt = state.finishedAt
+      if (payload.promise) newState.startedAt = state.startedAt
+      return newState
     default:
       return state
   }

--- a/packages/react-async/src/useAsync.js
+++ b/packages/react-async/src/useAsync.js
@@ -98,6 +98,10 @@ const useAsync = (arg1, arg2) => {
     isMounted.current && dispatch({ type: actionTypes.cancel, meta: getMeta() })
   }
 
+  const reinitialize = () =>
+    isMounted.current &&
+    dispatch({ type: actionTypes.reinitialize, payload: options, meta: getMeta() })
+
   const { watch, watchFn } = options
   useEffect(() => {
     if (watchFn && prevOptions.current && watchFn(options, prevOptions.current)) load()
@@ -117,6 +121,7 @@ const useAsync = (arg1, arg2) => {
       ...state,
       cancel,
       run,
+      reinitialize,
       reload: () => (lastArgs.current ? run(...lastArgs.current) : load()),
       setData,
       setError,

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -2,10 +2,9 @@
 
 import "jest-dom/extend-expect"
 import React from "react"
-import { render, fireEvent, cleanup, waitForElement } from "@testing-library/react"
+import { render, fireEvent, cleanup, waitForElement, wait } from "@testing-library/react"
 import { useAsync, useFetch } from "./index"
 import {
-  sleep,
   resolveTo,
   common,
   withPromise,
@@ -78,11 +77,52 @@ describe("useAsync", () => {
     const { getByText } = render(<App />)
     expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 0 }), abortCtrl)
     fireEvent.click(getByText("inc"))
-    await sleep(10) // resolve promiseFn
-    expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
+    await wait(() =>
+      expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
+    ) // resolve promiseFn
+
     fireEvent.click(getByText("run"))
-    await sleep(10) // resolve deferFn
-    expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
+    await wait(() =>
+      expect(promiseFn).toHaveBeenLastCalledWith(expect.objectContaining({ count: 1 }), abortCtrl)
+    ) // resolve deferFn
+  })
+
+  test("reinitializes the state", async () => {
+    const promiseFn = jest.fn().mockResolvedValue("some")
+    function App() {
+      const { data, isInitial, isPending, isFulfilled, isRejected, reinitialize } = useAsync({
+        promiseFn,
+      })
+      return (
+        <div>
+          <div data-testid="data">{`${data}`}</div>
+          <div data-testid="is-initial">{`${isInitial}`}</div>
+          <div data-testid="is-pending">{`${isPending}`}</div>
+          <div data-testid="is-fulfilled">{`${isFulfilled}`}</div>
+          <div data-testid="is-rejected">{`${isRejected}`}</div>
+          <button onClick={() => reinitialize()}>reinitialize</button>
+        </div>
+      )
+    }
+    const { getByText, getByTestId } = render(<App />)
+    expect(getByTestId("data")).toHaveTextContent("undefined")
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("true")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("false")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    await wait(() => expect(getByTestId("data")).toHaveTextContent("some"))
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("true")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    fireEvent.click(getByText("reinitialize"))
+    await wait(() => expect(getByTestId("data")).toHaveTextContent("undefined"))
+    expect(getByTestId("is-initial")).toHaveTextContent("true")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("false")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
   })
 })
 

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -87,7 +87,45 @@ describe("useAsync", () => {
     ) // resolve deferFn
   })
 
-  test("reinitializes the state", async () => {
+  test("reinitializes the state with promise", async () => {
+    const promise = jest.fn().mockResolvedValue("some")()
+    function App() {
+      const { data, isInitial, isPending, isFulfilled, isRejected, reinitialize } = useAsync({
+        promise,
+      })
+      return (
+        <div>
+          <div data-testid="data">{`${data}`}</div>
+          <div data-testid="is-initial">{`${isInitial}`}</div>
+          <div data-testid="is-pending">{`${isPending}`}</div>
+          <div data-testid="is-fulfilled">{`${isFulfilled}`}</div>
+          <div data-testid="is-rejected">{`${isRejected}`}</div>
+          <button onClick={() => reinitialize()}>reinitialize</button>
+        </div>
+      )
+    }
+    const { getByText, getByTestId } = render(<App />)
+    expect(getByTestId("data")).toHaveTextContent("undefined")
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("true")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("false")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    await wait(() => expect(getByTestId("data")).toHaveTextContent("some"))
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("true")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    fireEvent.click(getByText("reinitialize"))
+    await wait(() => expect(getByTestId("data")).toHaveTextContent("undefined"))
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("true")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("false")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+  })
+
+  test("reinitializes the state with promiseFn", async () => {
     const promiseFn = jest.fn().mockResolvedValue("some")
     function App() {
       const { data, isInitial, isPending, isFulfilled, isRejected, reinitialize } = useAsync({
@@ -119,9 +157,57 @@ describe("useAsync", () => {
 
     fireEvent.click(getByText("reinitialize"))
     await wait(() => expect(getByTestId("data")).toHaveTextContent("undefined"))
-    expect(getByTestId("is-initial")).toHaveTextContent("true")
-    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("true")
     expect(getByTestId("is-fulfilled")).toHaveTextContent("false")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+  })
+
+  test("reinitializes the state with promiseFn and initialValue", async () => {
+    const initVal = "some-initial-value"
+    const promiseFn = jest.fn().mockResolvedValue("some")
+    function App() {
+      const {
+        data,
+        initialValue,
+        isInitial,
+        isPending,
+        isFulfilled,
+        isRejected,
+        reinitialize,
+      } = useAsync({
+        promiseFn,
+        initialValue: initVal,
+      })
+      return (
+        <div>
+          <div data-testid="data">{`${data || initialValue}`}</div>
+          <div data-testid="is-initial">{`${isInitial}`}</div>
+          <div data-testid="is-pending">{`${isPending}`}</div>
+          <div data-testid="is-fulfilled">{`${isFulfilled}`}</div>
+          <div data-testid="is-rejected">{`${isRejected}`}</div>
+          <button onClick={() => reinitialize()}>reinitialize</button>
+        </div>
+      )
+    }
+    const { getByText, getByTestId } = render(<App />)
+    expect(getByTestId("data")).toHaveTextContent(initVal)
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("true")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    await wait(() => expect(getByTestId("data")).toHaveTextContent("some"))
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("true")
+    expect(getByTestId("is-rejected")).toHaveTextContent("false")
+
+    fireEvent.click(getByText("reinitialize"))
+    await wait(() => expect(getByTestId("data")).toHaveTextContent(initVal))
+    expect(getByTestId("is-initial")).toHaveTextContent("false")
+    expect(getByTestId("is-pending")).toHaveTextContent("false")
+    expect(getByTestId("is-fulfilled")).toHaveTextContent("true")
     expect(getByTestId("is-rejected")).toHaveTextContent("false")
   })
 })


### PR DESCRIPTION
# Description
This PR resolves https://github.com/ghengeveld/react-async/issues/58 which is about adding the `reinitialize` method.

## Breaking changes
N\A

# Checklist

Make sure you check all the boxes. You can omit items that are not applicable.

- [x] Implementation for both `<Async>` and `useAsync()`
- [x] Added / updated the unit tests
- [x] Added / updated the documentation
- [x] Updated the PropTypes
- [x] Updated the TypeScript type definitions
