### PR TITLE
Corrected some grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ Use it with `fetch`, Axios or other data fetching libraries, even GraphQL.
 
 ## Rationale
 
-React Async is different in that it tries to resolve data as close as possible to where it will be used, while using a
+React Async is different in that it tries to resolve data as close as possible to where it will be used, while using
 declarative syntax, using just JSX and native promises. This is in contrast to systems like Redux where you would
 configure any data fetching or updates on a higher (application global) level, using a special construct
 (actions/reducers).
 
-React Async works really well even in larger applications with multiple or nested data dependencies. It encourages loading
-data on-demand and in parallel at component level instead of in bulk at the route / page level. It's entirely decoupled
+React Async works well even in larger applications with multiple or nested data dependencies. It encourages loading
+data on-demand and in parallel at component level instead of in bulk at the route/
+page level. It's entirely decoupled
 from your routes, so it works well in complex applications that have a dynamic routing model or don't use routes at all.
 
 React Async is promise-based, so you can resolve anything you want, not just `fetch` requests.
@@ -102,8 +103,8 @@ a cache. It can render a fallback UI while loading data, much like `<Async.Loadi
 
 React Async has no direct relation to Concurrent React. They are conceptually close, but not the same. React Async is
 meant to make dealing with asynchronous business logic easier. Concurrent React will make those features have less
-impact on performance and usability. When Suspense lands, React Async will make full use of Suspense features. In fact
-you can already **start using React Async right now**, and in a later update you'll **get Suspense features for free**.
+impact on performance and usability. When Suspense lands, React Async will make full use of Suspense features. In fact,
+you can already **start using React Async right now**, and in a later update, you'll **get Suspense features for free**.
 
 [concurrent react]: https://github.com/sw-yx/fresh-concurrent-react/blob/master/Intro.md#introduction-what-is-concurrent-react
 


### PR DESCRIPTION
<h1>Description</h1>
<ul>

Corrected some grammatical errors. The explanation for these corrections are:-
1. The indefinite article <strong>a</strong>, may be reduntant when used with the uncountable noun syntax in your sentence. I have removed <strong>a</strong> before the word <strong>declarative</strong> in the documentation.

2. It appears that <strong>really</strong> is written unnecessarily in the documentation.

3. It appears that we have extra spaces surrounding the <strong>/</strong> between the words <strong>route</strong> and <strong>page</strong>. So I have removed that also. 