### PR TITLE
Expose wrapper promise as a prop so it can be chained on (fixes #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,9 +547,10 @@ is set to `"application/json"`.
 - `isRejected` true when the last promise was rejected.
 - `isSettled` true when the last promise was fulfilled or rejected (not initial or pending).
 - `counter` The number of times a promise was started.
-- `cancel` Cancel any pending promise.
+- `promise` A reference to the internal wrapper promise, which can be chained on.
 - `run` Invokes the `deferFn`.
 - `reload` Re-runs the promise when invoked, using any previous arguments.
+- `cancel` Cancel any pending promise.
 - `setData` Sets `data` to the passed value, unsets `error` and cancels any pending promise.
 - `setError` Sets `error` to the passed value and cancels any pending promise.
 
@@ -636,23 +637,31 @@ Alias: `isResolved`
 
 The number of times a promise was started.
 
-#### `cancel`
+#### `promise`
 
-> `function(): void`
+> `Promise`
 
-Cancels the currently pending promise by ignoring its result and calls `abort()` on the AbortController.
+A reference to the internal wrapper promise created when starting a new promise (either automatically or by invoking
+`run` / `reload`). It fulfills or rejects along with the provided `promise` / `promiseFn` / `deferFn`. Useful as a
+chainable alternative to the `onResolve` / `onReject` callbacks.
 
 #### `run`
 
-> `function(...args: any[]): Promise`
+> `function(...args: any[]): void`
 
-Runs the `deferFn`, passing any arguments provided as an array. The returned Promise always **fulfills** to `data` or `error`, it never rejects.
+Runs the `deferFn`, passing any arguments provided as an array.
 
 #### `reload`
 
 > `function(): void`
 
 Re-runs the promise when invoked, using the previous arguments.
+
+#### `cancel`
+
+> `function(): void`
+
+Cancels the currently pending promise by ignoring its result and calls `abort()` on the AbortController.
 
 #### `setData`
 

--- a/packages/react-async/src/Async.js
+++ b/packages/react-async/src/Async.js
@@ -32,6 +32,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
       this.mounted = false
       this.counter = 0
       this.args = []
+      this.promise = undefined
       this.abortController = { abort: () => {} }
       this.state = {
         ...init({ initialValue, promise, promiseFn }),
@@ -96,6 +97,7 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
     getMeta(meta) {
       return {
         counter: this.counter,
+        promise: this.promise,
         debugLabel: this.debugLabel,
         ...meta,
       }
@@ -107,11 +109,11 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
         this.abortController = new globalScope.AbortController()
       }
       this.counter++
-      return new Promise((resolve, reject) => {
+      return (this.promise = new Promise((resolve, reject) => {
         if (!this.mounted) return
         const executor = () => promiseFn().then(resolve, reject)
         this.dispatch({ type: actionTypes.start, payload: executor, meta: this.getMeta() })
-      })
+      }))
     }
 
     load() {

--- a/packages/react-async/src/Async.js
+++ b/packages/react-async/src/Async.js
@@ -118,19 +118,16 @@ export const createInstance = (defaultProps = {}, displayName = "Async") => {
 
     load() {
       const promise = this.props.promise
-      if (promise) {
-        return this.start(() => promise).then(
-          this.onResolve(this.counter),
-          this.onReject(this.counter)
-        )
-      }
       const promiseFn = this.props.promiseFn || defaultProps.promiseFn
-      if (promiseFn) {
+      if (promise) {
+        this.start(() => promise)
+          .then(this.onResolve(this.counter))
+          .catch(this.onReject(this.counter))
+      } else if (promiseFn) {
         const props = { ...defaultProps, ...this.props }
-        return this.start(() => promiseFn(props, this.abortController)).then(
-          this.onResolve(this.counter),
-          this.onReject(this.counter)
-        )
+        this.start(() => promiseFn(props, this.abortController))
+          .then(this.onResolve(this.counter))
+          .catch(this.onReject(this.counter))
       }
     }
 

--- a/packages/react-async/src/index.d.ts
+++ b/packages/react-async/src/index.d.ts
@@ -60,8 +60,9 @@ export interface AsyncProps<T> extends AsyncOptions<T> {
 interface AbstractState<T> {
   initialValue?: T | Error
   counter: number
+  promise: Promise<T>
   cancel: () => void
-  run: (...args: any[]) => Promise<T>
+  run: (...args: any[]) => void
   reload: () => void
   setData: (data: T, callback?: () => void) => T
   setError: (error: Error, callback?: () => void) => Error

--- a/packages/react-async/src/propTypes.js
+++ b/packages/react-async/src/propTypes.js
@@ -22,9 +22,10 @@ const stateObject =
     isRejected: PropTypes.bool,
     isSettled: PropTypes.bool,
     counter: PropTypes.number,
-    cancel: PropTypes.func,
+    promise: PropTypes.instanceOf(Promise),
     run: PropTypes.func,
     reload: PropTypes.func,
+    cancel: PropTypes.func,
     setData: PropTypes.func,
     setError: PropTypes.func,
   })

--- a/packages/react-async/src/reducer.js
+++ b/packages/react-async/src/reducer.js
@@ -16,6 +16,7 @@ export const init = ({ initialValue, promise, promiseFn }) => ({
   finishedAt: initialValue ? new Date() : undefined,
   ...getStatusProps(getInitialStatus(initialValue, promise || promiseFn)),
   counter: 0,
+  promise: undefined,
 })
 
 export const reducer = (state, { type, payload, meta }) => {
@@ -27,6 +28,7 @@ export const reducer = (state, { type, payload, meta }) => {
         finishedAt: undefined,
         ...getStatusProps(statusTypes.pending),
         counter: meta.counter,
+        promise: meta.promise,
       }
     case actionTypes.cancel:
       return {
@@ -35,6 +37,7 @@ export const reducer = (state, { type, payload, meta }) => {
         finishedAt: undefined,
         ...getStatusProps(getIdleStatus(state.error || state.data)),
         counter: meta.counter,
+        promise: meta.promise,
       }
     case actionTypes.fulfill:
       return {
@@ -44,6 +47,7 @@ export const reducer = (state, { type, payload, meta }) => {
         error: undefined,
         finishedAt: new Date(),
         ...getStatusProps(statusTypes.fulfilled),
+        promise: meta.promise,
       }
     case actionTypes.reject:
       return {
@@ -52,6 +56,7 @@ export const reducer = (state, { type, payload, meta }) => {
         value: payload,
         finishedAt: new Date(),
         ...getStatusProps(statusTypes.rejected),
+        promise: meta.promise,
       }
     default:
       return state

--- a/packages/react-async/src/useAsync.spec.js
+++ b/packages/react-async/src/useAsync.spec.js
@@ -93,7 +93,16 @@ describe("useAsync", () => {
       const [count, setCount] = React.useState(0)
       const onReject = count === 0 ? onReject1 : onReject2
       const { run } = useAsync({ deferFn, onReject })
-      return <button onClick={() => run(count) && setCount(1)}>run</button>
+      return (
+        <button
+          onClick={() => {
+            run(count)
+            setCount(1)
+          }}
+        >
+          run
+        </button>
+      )
     }
     const { getByText } = render(<App />)
     fireEvent.click(getByText("run"))
@@ -110,7 +119,7 @@ test("does not return a new `run` function on every render", async () => {
   const DeleteScheduleForm = () => {
     const [value, setValue] = React.useState()
     const { run } = useAsync({ deferFn })
-    React.useEffect(() => value && run() && undefined, [value, run])
+    React.useEffect(() => value && run(), [value, run])
     return <button onClick={() => setValue(true)}>run</button>
   }
   const component = <DeleteScheduleForm />


### PR DESCRIPTION
# Description

This exposes a new `promise` prop, which is the internal wrapper Promise created when starting the `promiseFn`. This wrapper promise fulfills and rejects along with the underlying promise, so it behaves as one would expect, contrary to the promise returned by `run`, which always fulfilled. Because the promise returned by `run` is an oddball and not frequently used (it was even untested), it was changed to just return `undefined`.

This fixes #79

# Breaking changes

The return type for `run` was changed from `Promise` to `undefined`. You should now use the `promise` prop instead. This change cannot be automated, so you should upgrade manually.

# Checklist

Make sure you check all the boxes. You can omit items that are not applicable.

- [x] Implementation for both `<Async>` and `useAsync()`
- [x] Added / updated the unit tests
- [x] Added / updated the documentation
- [x] Updated the PropTypes
- [x] Updated the TypeScript type definitions
